### PR TITLE
Report progress during indexing

### DIFF
--- a/lib/Command/Index.php
+++ b/lib/Command/Index.php
@@ -41,6 +41,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\ConsoleSectionOutput;
 
 class Index extends Command
 {
@@ -58,12 +59,14 @@ class Index extends Command
     protected TimelineWrite $timelineWrite;
 
     // Stats
+    private int $nUser = 0;
     private int $nProcessed = 0;
     private int $nSkipped = 0;
     private int $nInvalid = 0;
+    private int $nNoMedia = 0;
 
     // Helper for the progress bar
-    private int $previousLineLength = 0;
+    private ConsoleSectionOutput $outputSection;
 
     public function __construct(
         IRootFolder $rootFolder,
@@ -192,10 +195,11 @@ class Index extends Command
         // Show some stats
         $endTime = microtime(true);
         $execTime = (int) (($endTime - $startTime) * 1000) / 1000;
-        $nTotal = $this->nInvalid + $this->nSkipped + $this->nProcessed;
+        $nTotal = $this->nInvalid + $this->nSkipped + $this->nProcessed + $this->nNoMedia;
         $this->output->writeln('==========================================');
-        $this->output->writeln("Checked {$nTotal} files in {$execTime} sec");
+        $this->output->writeln("Checked {$nTotal} files of {$this->nUser} users in {$execTime} sec");
         $this->output->writeln($this->nInvalid.' not valid media items');
+        $this->output->writeln($this->nNoMedia.' .nomedia folders ignored');
         $this->output->writeln($this->nSkipped.' skipped because unmodified');
         $this->output->writeln($this->nProcessed.' (re-)processed');
         $this->output->writeln('==========================================');
@@ -245,31 +249,30 @@ class Index extends Command
 
         $uid = $user->getUID();
         $userFolder = $this->rootFolder->getUserFolder($uid);
-        $this->parseFolder($userFolder, $refresh);
-        if ($this->previousLineLength) {
-            $this->output->write("\r".str_repeat(' ', $this->previousLineLength)."\r");
-        }
+        $this->outputSection = $this->output->section();
+        $this->parseFolder($userFolder, $refresh, $this->nUser, $this->userManager->countSeenUsers());
+        $this->outputSection->overwrite('Scanned '.$userFolder->getPath());
+        ++$this->nUser;
     }
 
-    private function parseFolder(Folder &$folder, bool &$refresh): void
+    private function parseFolder(Folder &$folder, bool &$refresh, int $progress_i, int $progress_n): void
     {
         try {
             $folderPath = $folder->getPath();
 
             // Respect the '.nomedia' file. If present don't traverse the folder
             if ($folder->nodeExists('.nomedia')) {
-                $this->output->writeln('Skipping folder '.$folderPath.' because of .nomedia file');
-                $this->previousLineLength = 0;
-
+                ++$this->nNoMedia;
                 return;
             }
 
             $nodes = $folder->getDirectoryListing();
 
-            foreach ($nodes as &$node) {
+            foreach ($nodes as $i=>&$node) {
                 if ($node instanceof Folder) {
-                    $this->parseFolder($node, $refresh);
+                    $this->parseFolder($node, $refresh, $progress_i * count($nodes) + $i, $progress_n * count($nodes));
                 } elseif ($node instanceof File) {
+                    $this->outputSection->overwrite(sprintf("%.2f%%", $progress_i/$progress_n*100).' scanning '.$node->getPath());
                     $this->parseFile($node, $refresh);
                 }
             }
@@ -284,14 +287,6 @@ class Index extends Command
 
     private function parseFile(File &$file, bool &$refresh): void
     {
-        // Clear previous line and write new one
-        $line = 'Scanning file '.$file->getPath();
-        if ($this->previousLineLength) {
-            $this->output->write("\r".str_repeat(' ', $this->previousLineLength)."\r");
-        }
-        $this->output->write($line."\r");
-        $this->previousLineLength = \strlen($line);
-
         // Process the file
         $res = $this->timelineWrite->processFile($file, $refresh);
         if (2 === $res) {


### PR DESCRIPTION
Besides adding a percentage progress, this also exploits the ConsoleSectionOutput capability of Symfony to simplify the carriage return gymnastics and to fix it for paths exceeding the console window width.

Tested on NC 25.0.1