### PR TITLE
Use mkdir -p instead of mkdir --parents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ exiftool:
 	sh scripts/get-exiftool.sh
 
 php-cs-fixer:
-	mkdir --parents tools/php-cs-fixer
+	mkdir -p tools/php-cs-fixer
 	composer require --working-dir=tools/php-cs-fixer friendsofphp/php-cs-fixer
 
 php-lint:


### PR DESCRIPTION
Hey, thanks for creating this great app. 

When I tried to set up a development environment on MacOS, I received the error `mkdir: illegal option -- -` from the `make` command. This is because the long form parameters for `mkdir` are not available on MacOS. I believe the `-p` option is more widely available.