### PR TITLE
Add move to folder feature

### DIFF
--- a/src/components/SelectionManager.vue
+++ b/src/components/SelectionManager.vue
@@ -44,6 +44,7 @@
       :updateLoading="updateLoading"
     />
     <AddToAlbumModal ref="addToAlbumModal" @added="clearSelection" />
+    <MoveToFolderModal ref="moveToFolderModal" @moved="refresh" />
   </div>
 </template>
 
@@ -73,6 +74,7 @@ import EditDate from "./modal/EditDate.vue";
 import EditExif from "./modal/EditExif.vue";
 import FaceMoveModal from "./modal/FaceMoveModal.vue";
 import AddToAlbumModal from "./modal/AddToAlbumModal.vue";
+import MoveToFolderModal from "./modal/MoveToFolderModal.vue";
 
 import StarIcon from "vue-material-design-icons/Star.vue";
 import DownloadIcon from "vue-material-design-icons/Download.vue";
@@ -86,6 +88,7 @@ import CloseIcon from "vue-material-design-icons/Close.vue";
 import MoveIcon from "vue-material-design-icons/ImageMove.vue";
 import AlbumsIcon from "vue-material-design-icons/ImageAlbum.vue";
 import AlbumRemoveIcon from "vue-material-design-icons/BookRemove.vue";
+import FolderMoveIcon from "vue-material-design-icons/FolderMove.vue";
 
 type Selection = Map<number, IPhoto>;
 
@@ -98,6 +101,7 @@ export default defineComponent({
     EditExif,
     FaceMoveModal,
     AddToAlbumModal,
+    MoveToFolderModal,
 
     CloseIcon,
   },
@@ -184,6 +188,12 @@ export default defineComponent({
         icon: OpenInNewIcon,
         callback: this.viewInFolder.bind(this),
         if: () => this.selection.size === 1 && !this.routeIsAlbum(),
+      },
+      {
+        name: t("memories", "Move to folder"),
+        icon: FolderMoveIcon,
+        callback: this.moveToFolder.bind(this),
+        if: () => !this.routeIsAlbum() && !this.routeIsArchive(),
       },
       {
         name: t("memories", "Add to album"),
@@ -798,6 +808,13 @@ export default defineComponent({
      */
     async addToAlbum(selection: Selection) {
       (<any>this.$refs.addToAlbumModal).open(Array.from(selection.values()));
+    },
+
+    /**
+     * Move selected photos to folder
+     */
+    async moveToFolder(selection: Selection) {
+      (<any>this.$refs.moveToFolderModal).open(Array.from(selection.values()));
     },
 
     /**

--- a/src/components/modal/MoveToFolderModal.vue
+++ b/src/components/modal/MoveToFolderModal.vue
@@ -1,0 +1,107 @@
+<template>
+  <Modal @close="close" size="normal" v-if="processing">
+    <template #title>
+      {{ t("memories", "Move to folder") }}
+    </template>
+
+    <div class="outer">
+      {{
+        t("memories", "Processing … {n}/{m}", {
+          n: photosDone,
+          m: photos.length,
+        })
+      }}
+    </div>
+  </Modal>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+import * as dav from "../../services/DavRequests";
+import { getFilePickerBuilder, FilePickerType } from "@nextcloud/dialogs";
+import { showInfo } from "@nextcloud/dialogs";
+import { IPhoto } from "../../types";
+
+import Modal from "./Modal.vue";
+
+export default defineComponent({
+  name: "MoveToFolderModal",
+  components: {
+    Modal,
+  },
+
+  data: () => ({
+    photos: [] as IPhoto[],
+    photosDone: 0,
+    processing: false,
+  }),
+
+  methods: {
+    open(photos: IPhoto[]) {
+      this.photosDone = 0;
+      this.processing = false;
+      this.photos = photos;
+
+      this.chooseFolderPath();
+    },
+
+    moved(photos: IPhoto[]) {
+      this.$emit("moved", photos);
+    },
+
+    close() {
+      this.photos = [];
+      this.processing = false;
+      this.$emit("close");
+    },
+
+    async chooseFolderModal(title: string, initial: string) {
+      const picker = getFilePickerBuilder(title)
+        .setMultiSelect(false)
+        .setModal(false)
+        .setType(FilePickerType.Move)
+        .addMimeTypeFilter("httpd/unix-directory")
+        .allowDirectories()
+        .startAt(initial)
+        .build();
+
+      return await picker.pick();
+    },
+
+    async chooseFolderPath() {
+      let destination = await this.chooseFolderModal(
+        this.t("memories", "Choose a folder"),
+        this.config_foldersPath
+      );
+      // Fails if the target exists, same behavior with Nextcloud files implementation.
+      const gen = dav.movePhotos(this.photos, destination, false);
+      this.processing = true;
+
+      for await (const fids of gen) {
+        this.photosDone += fids.filter((f) => f).length;
+        this.moved(this.photos.filter((p) => fids.includes(p.fileid)));
+      }
+
+      const n = this.photosDone;
+      showInfo(
+        this.n(
+          "memories",
+          "{n} item moved to folder",
+          "{n} items moved to folder",
+          n,
+          { n }
+        )
+      );
+      this.close();
+
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.outer {
+  margin-top: 15px;
+}
+</style>


### PR DESCRIPTION
I've been looking for a 'perfect' self hosted gallery app for some time, and this is the best I could find so far. So thanks for this project!

While I am using this app though, I notice couple of features fell short, which are important for my use-case. So moving multiple photos from timeline and folders to another folder is the one I need at the moment (effectively fixes #204 - only move part though). So I decided to implement this. I understand that if this won't be prioritized (I'll use my fork anyway 😄) or cancelled all together.

Couple of notes:
- Webdav natively supports `MOVE`, so just using it as similar to Nextcloud files.
- If the target exists, it'll fail. (again, same behavior with Nextcloud files).
- Not enabling move in albums and archive as it would probably be doing something that user didn't intend.
- Not adding move operation to context menu of photo view as that doesn't seem very useful (at least to me) so didn't want to add unnecessary noise.
- Using very similar approaches to adding to album and deleting photos.

