### PR TITLE
Implement prepared statements in TimelineWrite

### DIFF
--- a/lib/Db/TimelineWrite.php
+++ b/lib/Db/TimelineWrite.php
@@ -6,8 +6,8 @@ namespace OCA\Memories\Db;
 
 use OCA\Memories\AppInfo\Application;
 use OCA\Memories\Exif;
-use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\IPreparedStatement;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
 use OCP\IDBConnection;
 use OCP\IPreview;
@@ -30,13 +30,15 @@ class TimelineWrite
         $this->preview = \OC::$server->get(IPreview::class);
         $this->livePhoto = new LivePhoto($connection);
 
-        $selectBuilder = function ($table) : IPreparedStatement {
+        $selectBuilder = function ($table): IPreparedStatement {
             $query = $this->connection->getQueryBuilder();
             $sql = $query->select('fileid', 'mtime')
                 ->from($table)
                 ->where($query->expr()->eq('fileid', $query->createParameter('fileid')))
                 ->setMaxResults(1)
-                ->getSQL();
+                ->getSQL()
+            ;
+
             return $this->connection->prepare($sql);
         };
         $this->selectMemories = $selectBuilder('memories');
@@ -44,7 +46,7 @@ class TimelineWrite
 
         // Update existing row
         // No need to set objectid again
-        $query= $this->connection->getQueryBuilder();
+        $query = $this->connection->getQueryBuilder();
         $sql = $query->update('memories')
             ->set('dayid', $query->createParameter('dayid'))
             ->set('datetaken', $query->createParameter('datetaken'))
@@ -57,7 +59,8 @@ class TimelineWrite
             ->set('liveid', $query->createParameter('liveid'))
             ->where($query->expr()->eq('fileid', $query->createParameter('fileid')))
             ->setMaxResults(1)
-            ->getSQL();
+            ->getSQL()
+        ;
         $this->updateMemories = $this->connection->prepare($sql);
 
         // Create new row
@@ -74,17 +77,20 @@ class TimelineWrite
                 'w' => $query->createParameter('w'),
                 'h' => $query->createParameter('h'),
                 'exif' => $query->createParameter('exif'),
-                'liveid' => $query->createParameter('liveid')
+                'liveid' => $query->createParameter('liveid'),
             ])
-            ->getSQL();
+            ->getSQL()
+        ;
         $this->insertMemories = $this->connection->prepare($sql);
 
-        $deleteBuilder = function ($table) : IPreparedStatement {
+        $deleteBuilder = function ($table): IPreparedStatement {
             $query = $this->connection->getQueryBuilder();
             $sql = $query->delete($table)
                 ->where($query->expr()->eq('fileid', $query->createParameter('fileid')))
                 ->setMaxResults(1)
-                ->getSQL();
+                ->getSQL()
+            ;
+
             return $this->connection->prepare($sql);
         };
         $this->deleteMemories = $deleteBuilder('memories');

--- a/lib/Db/TimelineWrite.php
+++ b/lib/Db/TimelineWrite.php
@@ -7,6 +7,7 @@ namespace OCA\Memories\Db;
 use OCA\Memories\AppInfo\Application;
 use OCA\Memories\Exif;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\DB\IPreparedStatement;
 use OCP\Files\File;
 use OCP\IDBConnection;
 use OCP\IPreview;
@@ -16,12 +17,78 @@ class TimelineWrite
     protected IDBConnection $connection;
     protected IPreview $preview;
     protected LivePhoto $livePhoto;
+    protected IPreparedStatement $selectMemories;
+    protected IPreparedStatement $selectMemoriesLivePhoto;
+    protected IPreparedStatement $updateMemories;
+    protected IPreparedStatement $insertMemories;
+    protected IPreparedStatement $deleteMemories;
+    protected IPreparedStatement $deleteMemoriesLivePhoto;
 
     public function __construct(IDBConnection $connection)
     {
         $this->connection = $connection;
         $this->preview = \OC::$server->get(IPreview::class);
         $this->livePhoto = new LivePhoto($connection);
+
+        $selectBuilder = function ($table) : IPreparedStatement {
+            $query = $this->connection->getQueryBuilder();
+            $sql = $query->select('fileid', 'mtime')
+                ->from($table)
+                ->where($query->expr()->eq('fileid', $query->createParameter('fileid')))
+                ->setMaxResults(1)
+                ->getSQL();
+            return $this->connection->prepare($sql);
+        };
+        $this->selectMemories = $selectBuilder('memories');
+        $this->selectMemoriesLivePhoto = $selectBuilder('memories_livephoto');
+
+        // Update existing row
+        // No need to set objectid again
+        $query= $this->connection->getQueryBuilder();
+        $sql = $query->update('memories')
+            ->set('dayid', $query->createParameter('dayid'))
+            ->set('datetaken', $query->createParameter('datetaken'))
+            ->set('mtime', $query->createParameter('mtime'))
+            ->set('isvideo', $query->createParameter('isvideo'))
+            ->set('video_duration', $query->createParameter('video_duration'))
+            ->set('w', $query->createParameter('w'))
+            ->set('h', $query->createParameter('h'))
+            ->set('exif', $query->createParameter('exif'))
+            ->set('liveid', $query->createParameter('liveid'))
+            ->where($query->expr()->eq('fileid', $query->createParameter('fileid')))
+            ->setMaxResults(1)
+            ->getSQL();
+        $this->updateMemories = $this->connection->prepare($sql);
+
+        // Create new row
+        $query = $this->connection->getQueryBuilder();
+        $sql = $query->insert('memories')
+            ->values([
+                'fileid' => $query->createParameter('fileid'),
+                'objectid' => $query->createParameter('objectid'),
+                'dayid' => $query->createParameter('dayid'),
+                'datetaken' => $query->createParameter('datetaken'),
+                'mtime' => $query->createParameter('mtime'),
+                'isvideo' => $query->createParameter('isvideo'),
+                'video_duration' => $query->createParameter('video_duration'),
+                'w' => $query->createParameter('w'),
+                'h' => $query->createParameter('h'),
+                'exif' => $query->createParameter('exif'),
+                'liveid' => $query->createParameter('liveid')
+            ])
+            ->getSQL();
+        $this->insertMemories = $this->connection->prepare($sql);
+
+        $deleteBuilder = function ($table) : IPreparedStatement {
+            $query = $this->connection->getQueryBuilder();
+            $sql = $query->delete($table)
+                ->where($query->expr()->eq('fileid', $query->createParameter('fileid')))
+                ->setMaxResults(1)
+                ->getSQL();
+            return $this->connection->prepare($sql);
+        };
+        $this->deleteMemories = $deleteBuilder('memories');
+        $this->deleteMemoriesLivePhoto = $deleteBuilder('memories_livephoto');
     }
 
     /**
@@ -73,23 +140,15 @@ class TimelineWrite
         $fileId = $file->getId();
 
         // Check if need to update
-        $query = $this->connection->getQueryBuilder();
-        $query->select('fileid', 'mtime')
-            ->from('memories')
-            ->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
-        ;
-        $cursor = $query->executeQuery();
+        $this->selectMemories->bindValue('fileid', $fileId, IQueryBuilder::PARAM_INT);
+        $cursor = $this->selectMemories->execute();
         $prevRow = $cursor->fetch();
         $cursor->closeCursor();
 
         // Check in live-photo table in case this is a video part of a live photo
         if (!$prevRow) {
-            $query = $this->connection->getQueryBuilder();
-            $query->select('fileid', 'mtime')
-                ->from('memories_livephoto')
-                ->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
-            ;
-            $cursor = $query->executeQuery();
+            $this->selectMemoriesLivePhoto->bindValue('fileid', $fileId, IQueryBuilder::PARAM_INT);
+            $cursor = $this->selectMemoriesLivePhoto->execute();
             $prevRow = $cursor->fetch();
             $cursor->closeCursor();
         }
@@ -151,44 +210,23 @@ class TimelineWrite
             $exifJson = json_encode(['error' => 'Exif data encoding error']);
         }
 
-        if ($prevRow) {
-            // Update existing row
-            // No need to set objectid again
-            $query->update('memories')
-                ->set('dayid', $query->createNamedParameter($dayId, IQueryBuilder::PARAM_INT))
-                ->set('datetaken', $query->createNamedParameter($dateTaken, IQueryBuilder::PARAM_STR))
-                ->set('mtime', $query->createNamedParameter($mtime, IQueryBuilder::PARAM_INT))
-                ->set('isvideo', $query->createNamedParameter($isvideo, IQueryBuilder::PARAM_INT))
-                ->set('video_duration', $query->createNamedParameter($videoDuration, IQueryBuilder::PARAM_INT))
-                ->set('w', $query->createNamedParameter($w, IQueryBuilder::PARAM_INT))
-                ->set('h', $query->createNamedParameter($h, IQueryBuilder::PARAM_INT))
-                ->set('exif', $query->createNamedParameter($exifJson, IQueryBuilder::PARAM_STR))
-                ->set('liveid', $query->createNamedParameter($liveid, IQueryBuilder::PARAM_STR))
-                ->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
-            ;
-            $query->executeStatement();
-        } else {
-            // Try to create new row
-            try {
-                $query->insert('memories')
-                    ->values([
-                        'fileid' => $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT),
-                        'objectid' => $query->createNamedParameter((string) $fileId, IQueryBuilder::PARAM_STR),
-                        'dayid' => $query->createNamedParameter($dayId, IQueryBuilder::PARAM_INT),
-                        'datetaken' => $query->createNamedParameter($dateTaken, IQueryBuilder::PARAM_STR),
-                        'mtime' => $query->createNamedParameter($mtime, IQueryBuilder::PARAM_INT),
-                        'isvideo' => $query->createNamedParameter($isvideo, IQueryBuilder::PARAM_INT),
-                        'video_duration' => $query->createNamedParameter($videoDuration, IQueryBuilder::PARAM_INT),
-                        'w' => $query->createNamedParameter($w, IQueryBuilder::PARAM_INT),
-                        'h' => $query->createNamedParameter($h, IQueryBuilder::PARAM_INT),
-                        'exif' => $query->createNamedParameter($exifJson, IQueryBuilder::PARAM_STR),
-                        'liveid' => $query->createNamedParameter($liveid, IQueryBuilder::PARAM_STR),
-                    ])
-                ;
-                $query->executeStatement();
-            } catch (\Exception $ex) {
-                error_log('Failed to create memories record: '.$ex->getMessage());
-            }
+        $query = $prevRow ? $this->updateMemories : $this->insertMemories;
+        $query->bindValue('fileid', $fileId, IQueryBuilder::PARAM_INT);
+        $query->bindValue('objectid', (string) $fileId, IQueryBuilder::PARAM_STR);
+        $query->bindValue('dayid', $dayId, IQueryBuilder::PARAM_INT);
+        $query->bindValue('datetaken', $dateTaken, IQueryBuilder::PARAM_STR);
+        $query->bindValue('mtime', $mtime, IQueryBuilder::PARAM_INT);
+        $query->bindValue('isvideo', $isvideo, IQueryBuilder::PARAM_INT);
+        $query->bindValue('video_duration', $videoDuration, IQueryBuilder::PARAM_INT);
+        $query->bindValue('w', $w, IQueryBuilder::PARAM_INT);
+        $query->bindValue('h', $h, IQueryBuilder::PARAM_INT);
+        $query->bindValue('exif', $exifJson, IQueryBuilder::PARAM_STR);
+        $query->bindValue('liveid', $liveId, IQueryBuilder::PARAM_STR);
+
+        try {
+            $query->execute();
+        } catch (\Exception $ex) {
+            error_log('Failed to write memories record: '.$ex->getMessage());
         }
 
         return 2;
@@ -199,15 +237,12 @@ class TimelineWrite
      */
     public function deleteFile(File &$file)
     {
-        $deleteFrom = function ($table) use (&$file) {
-            $query = $this->connection->getQueryBuilder();
-            $query->delete($table)
-                ->where($query->expr()->eq('fileid', $query->createNamedParameter($file->getId(), IQueryBuilder::PARAM_INT)))
-            ;
-            $query->executeStatement();
+        $deleteFrom = function ($query) use (&$file) {
+            $query->bindValue('fileid', $file->getId(), IQueryBuilder::PARAM_INT);
+            $query->execute();
         };
-        $deleteFrom('memories');
-        $deleteFrom('memories_livephoto');
+        $deleteFrom($this->deleteMemories);
+        $deleteFrom($this->deleteMemoriesLivePhoto);
     }
 
     /**


### PR DESCRIPTION
I noticed that when running `occ memories:index`, TimelineWrite would build a new query for every CRUD operation on every file processed. Creating an `IPreparedStatement` in the constructor builds the query once and re-uses it for each file processed. When re-scanning an image directory, this improved the overall speed by around 20%.

Before:
```
==========================================
Checked 289903 files of 4 users in 50.25 sec
6217 not valid media items
4 .nomedia folders ignored
283682 skipped because unmodified
0 (re-)processed
==========================================
```

After:
```
==========================================
Checked 289903 files of 4 users in 41.062 sec
6217 not valid media items
4 .nomedia folders ignored
283682 skipped because unmodified
0 (re-)processed
==========================================
```