### PR TITLE
Sort albums by name rather than creation time

### DIFF
--- a/lib/Db/TimelineQueryAlbums.php
+++ b/lib/Db/TimelineQueryAlbums.php
@@ -63,7 +63,7 @@ trait TimelineQueryAlbums
 
         // GROUP and ORDER by
         $query->groupBy('pa.album_id');
-        $query->orderBy('pa.created', 'DESC');
+        $query->orderBy('pa.name', 'ASC');
         $query->addOrderBy('pa.album_id', 'DESC'); // tie-breaker
 
         // FETCH all albums


### PR DESCRIPTION
Small change to load albums by name. As reasoned in #377, that seems like a more useful sort order than creation time.