### PR TITLE
make endpoint accessible for external yet authenticated clients

### DIFF
--- a/lib/Controller/DaysController.php
+++ b/lib/Controller/DaysController.php
@@ -159,8 +159,7 @@ class DaysController extends ApiBase
 
     /**
      * @NoAdminRequired
-     *
-     * @PublicPage
+     * @NoCSRFRequired
      */
     public function dayPost(): JSONResponse
     {


### PR DESCRIPTION
I always envied iphone users for the "Memories" feature of the Photos app . Then i found your nextcloud app. So thanks for that!
Then i started an android app that (so far) only replicates the show-"on this day n years ago"-photos: https://github.com/thrillfall/android-nextcloud-memories
It is just a proof-of-concept (code is still some big spaghetti-mud-ball) and is simply displays all thumbnails in a plain 2-column view. 

Once this has a nice user interface and experience i'd like to publish this on F-Droid. Would it be ok if this android app was named "Nextcloud Memories"? Thus being explicitly coupled to your nextcloud app?

My android/kotlin is still in newbi stage and i'd appreciate any help and additional functionality contributions.
What are your thought on this?

If you want to give it a try you'd have to apply the changes from this PR to your nextcloud instance and could use this build: https://github.com/thrillfall/android-nextcloud-memories/blob/653e2e16563576de5c95e3d7ab9272feb2592ae4/nextcloud_memories_debug.apk
