### PR TITLE
Fix timezone stripping when parsing exif dates

### DIFF
--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -180,26 +180,16 @@ class Exif
      */
     public static function getDateTaken(File &$file, array &$exif)
     {
+        // Try to parse the date from exif metadata
         $dt = $exif['DateTimeOriginal'] ?? null;
-        if (!isset($dt) || empty($dt)) {
-            $dt = $exif['CreateDate'] ?? null;
-        }
-
-        // Check if found something
         try {
             return self::parseExifDate($dt);
         } catch (\Exception $ex) {
         } catch (\ValueError $ex) {
         }
 
-        // Fall back to creation time
-        $dateTaken = $file->getCreationTime();
-
         // Fall back to modification time
-        if (0 === $dateTaken) {
-            $dateTaken = $file->getMtime();
-        }
-
+        $dateTaken = $file->getMtime();
         return self::forgetTimezone($dateTaken);
     }
 


### PR DESCRIPTION
Hello, I encountered some issues while importing videos where creation dates are stored with the following format:

![immagine](https://user-images.githubusercontent.com/15969021/217680718-31b89706-46fb-4d72-b615-9af787f1c523.png)

As you can see, in some cases the timezone is stored using a different pattern.
This pull request is enhancing the current logic that strip the timezone to also take in consideration this case.