### PR TITLE
Face Recognition: Fix query to not show individual clusters

### DIFF
--- a/lib/Controller/PeopleController.php
+++ b/lib/Controller/PeopleController.php
@@ -129,15 +129,14 @@ class PeopleController extends ApiBase
 
         // Run actual query
         $currentModel = (int) $this->config->getAppValue('facerecognition', 'model', -1);
-        $list = $this->timelineQuery->getPeopleFaceRecognition(
+        $list = $this->timelineQuery->getFaceRecognitionPersons(
             $root,
-            $currentModel,
+            $currentModel
         );
         // Just append unnamed clusters to the end.
-        $list = array_merge($list, $this->timelineQuery->getPeopleFaceRecognition(
+        $list = array_merge($list, $this->timelineQuery->getFaceRecognitionClusters(
             $root,
-            $currentModel,
-            true
+            $currentModel
         ));
 
         return new JSONResponse($list, Http::STATUS_OK);

--- a/lib/Db/TimelineQueryPeopleFaceRecognition.php
+++ b/lib/Db/TimelineQueryPeopleFaceRecognition.php
@@ -59,15 +59,6 @@ trait TimelineQueryPeopleFaceRecognition
         );
     }
 
-    public function getPeopleFaceRecognition(TimelineRoot &$root, int $currentModel, bool $show_clusters = false, bool $show_singles = false, bool $show_hidden = false)
-    {
-        if ($show_clusters) {
-            return $this->getFaceRecognitionClusters($root, $currentModel, $show_singles, $show_hidden);
-        }
-
-        return $this->getFaceRecognitionPersons($root, $currentModel);
-    }
-
     public function getFaceRecognitionPreview(TimelineRoot &$root, $currentModel, $previewId)
     {
         $query = $this->connection->getQueryBuilder();
@@ -162,7 +153,7 @@ trait TimelineQueryPeopleFaceRecognition
         return $previews;
     }
 
-    private function getFaceRecognitionClusters(TimelineRoot &$root, int $currentModel, bool $show_singles = false, bool $show_hidden = false)
+    public function getFaceRecognitionClusters(TimelineRoot &$root, int $currentModel, bool $show_singles = false, bool $show_hidden = false)
     {
         $query = $this->connection->getQueryBuilder();
 
@@ -194,7 +185,7 @@ trait TimelineQueryPeopleFaceRecognition
 
         // By default hides individual faces when they have no name.
         if (!$show_singles) {
-            $query->having($count, $query->createNamedParameter(1));
+            $query->having($query->expr()->gt($count, $query->createNamedParameter(1)));
         }
 
         // By default it shows the people who were not hidden
@@ -222,7 +213,7 @@ trait TimelineQueryPeopleFaceRecognition
         return $faces;
     }
 
-    private function getFaceRecognitionPersons(TimelineRoot &$root, int $currentModel)
+    public function getFaceRecognitionPersons(TimelineRoot &$root, int $currentModel)
     {
         $query = $this->connection->getQueryBuilder();
 


### PR DESCRIPTION
It was working incorrectly since my last PR. Sorry.

Note that may seem useful to show them all, but it ends up being a never-ending task that annoys the user.

On the other hand, I made two public functions to improve the readability of the controller code.