### PR TITLE
Fix /memories/api/albums API to return JSON array

### DIFF
--- a/lib/Controller/AlbumsController.php
+++ b/lib/Controller/AlbumsController.php
@@ -65,6 +65,9 @@ class AlbumsController extends ApiBase
             return true;
         });
 
+        // Convert $list to sequential array
+        $list = array_values($list);
+
         return new JSONResponse($list, Http::STATUS_OK);
     }
 


### PR DESCRIPTION
## Problem
`/memories/api/albums` API returns a JSON object (expected: JSON array) when some albums are filtered [here](https://github.com/pulsejet/memories/blob/e207d3a8c55c7c831c6202fb7961f5826aeda00a/lib/Controller/AlbumsController.php#L59-L66).

This causes the following error.
<img width="999" alt="image" src="https://user-images.githubusercontent.com/1780508/226515508-18623936-4f6e-4c36-9c05-4de44d77fb55.png">


## Why
`json_encode` (called in [JSONResponse](https://github.com/pulsejet/memories/blob/e207d3a8c55c7c831c6202fb7961f5826aeda00a/lib/Controller/AlbumsController.php#L68)) generates JSON object when non sequential array is given.


## How to fixed
Use `array_values` to convert to sequential array.