### PR TITLE
Escaping issues with single quotes

### DIFF
--- a/src/Admin.vue
+++ b/src/Admin.vue
@@ -244,7 +244,7 @@
       {{
         t(
           "memories",
-          "Note: the geometry data is stored in the 'memories_planet_geometry' table, with no prefix."
+          "Note: the geometry data is stored in the \'memories_planet_geometry\' table, with no prefix."
         )
       }}
     </p>


### PR DESCRIPTION
The string has a escaping issue as it breaks on the first single quotes, i've opened this PR to propose the solution enclosed, or, alternatively, use double quotes which wouldn't require escaping. Which of course causes rejection of this PR, in any case, this is to ensure proper translation string gets thru in the next nextcloud-bot run.

Thanks for your consideration.

