### PR TITLE
Add x-msvideo mime type

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -57,6 +57,7 @@ class Application extends App implements IBootstrap
         'video/quicktime',
         'video/x-matroska',
         'video/MP2T',
+        'video/x-msvideo',
         // 'video/x-m4v',       // too rarely used for photos
         // 'video/ogg',         // too rarely used for photos
     ];


### PR DESCRIPTION
Videos from my (old) Powershot A80 (avi files) are not processed by memories because their mime type is 'video/x-msvideo'.
Would it be possible to add this mime type by default ?
Thank you very much for your work.

David

Edit: Just a few more information: 

I tested it after adding the type in Application.php and it works perfectly.
Here is an example of these video files:
[MVI_4254.zip](https://github.com/pulsejet/memories/files/11302932/MVI_4254.zip)