### PR TITLE
Add configuration for full res on zoom and full res always for public shares

### DIFF
--- a/lib/Controller/OtherController.php
+++ b/lib/Controller/OtherController.php
@@ -94,6 +94,9 @@ class OtherController extends GenericApiController
                 'sort_folder_month' => 'true' === $getAppConfig('sortFolderMonth', false),
                 'sort_album_month' => 'true' === $getAppConfig('sortAlbumMonth', 'true'),
                 'enable_top_memories' => 'true' === $getAppConfig('enableTopMemories', 'true'),
+
+                'public_full_res_on_zoom' => Util::getSystemConfig('memories.public_full_res_on_zoom'),
+                'public_full_res_always' => Util::getSystemConfig('memories.public_full_res_always'),
             ], Http::STATUS_OK);
         });
     }

--- a/lib/Controller/OtherController.php
+++ b/lib/Controller/OtherController.php
@@ -95,8 +95,8 @@ class OtherController extends GenericApiController
                 'sort_album_month' => 'true' === $getAppConfig('sortAlbumMonth', 'true'),
                 'enable_top_memories' => 'true' === $getAppConfig('enableTopMemories', 'true'),
 
-                'public_full_res_on_zoom' => Util::getSystemConfig('memories.public_full_res_on_zoom'),
-                'public_full_res_always' => Util::getSystemConfig('memories.public_full_res_always'),
+                'global_full_res_on_zoom' => Util::getSystemConfig('memories.global_full_res_on_zoom'),
+                'global_full_res_always' => Util::getSystemConfig('memories.global_full_res_always'),
             ], Http::STATUS_OK);
         });
     }

--- a/lib/SystemConfigDefault.php
+++ b/lib/SystemConfigDefault.php
@@ -70,6 +70,6 @@ return [
     'preview_max_memory' => 128,
     'preview_max_filesize_image' => 50,
 
-    'memories.public_full_res_on_zoom' => true,
-    'memories.public_full_res_always' => false,
+    'memories.global_full_res_on_zoom' => true,
+    'memories.global_full_res_always' => false,
 ];

--- a/lib/SystemConfigDefault.php
+++ b/lib/SystemConfigDefault.php
@@ -69,4 +69,7 @@ return [
     'preview_max_y' => 4096,
     'preview_max_memory' => 128,
     'preview_max_filesize_image' => 50,
+
+    'memories.public_full_res_on_zoom' => true,
+    'memories.public_full_res_always' => false,
 ];

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -44,11 +44,22 @@
         >
           {{ t('memories', 'Show past photos on top of timeline') }}
         </NcCheckboxRadioSwitch>
+      </NcAppSettingsSection>
+
+      <NcAppSettingsSection id="preview-settings" :title="t('memories', 'Previews')">
+        <NcCheckboxRadioSwitch
+          :checked.sync="config.override_global_full_res"
+          @update:checked="updateOverrideGlobalFullRes"
+          type="switch"
+        >
+          {{ t('memories', 'Override the global settings for loading full size images') }}
+        </NcCheckboxRadioSwitch>
 
         <NcCheckboxRadioSwitch
           :checked.sync="config.full_res_on_zoom"
           @update:checked="updateFullResOnZoom"
           type="switch"
+          :disabled="!config.override_global_full_res"
         >
           {{ t('memories', 'Load full size image on zoom') }}
         </NcCheckboxRadioSwitch>
@@ -56,6 +67,7 @@
         <NcCheckboxRadioSwitch
           :checked.sync="config.full_res_always"
           @update:checked="updateFullResAlways"
+          :disabled="!config.override_global_full_res"
           type="switch"
         >
           {{ t('memories', 'Always load full size image (not recommended)') }}
@@ -217,6 +229,10 @@ export default defineComponent({
 
     async updateSquareThumbs() {
       await this.updateSetting('square_thumbs');
+    },
+
+    async updateOverrideGlobalFullRes() {
+      await this.updateSetting('override_global_full_res');
     },
 
     async updateFullResOnZoom() {

--- a/src/components/admin/AdminTypes.ts
+++ b/src/components/admin/AdminTypes.ts
@@ -28,6 +28,9 @@ export type ISystemConfig = {
   preview_max_y: number;
   preview_max_memory: number;
   preview_max_filesize_image: number;
+
+  'memories.public_full_res_on_zoom': boolean;
+  'memories.public_full_res_always': boolean;
 };
 
 export type IBinaryStatus = 'ok' | 'not_found' | 'not_executable' | 'test_ok' | string;

--- a/src/components/admin/AdminTypes.ts
+++ b/src/components/admin/AdminTypes.ts
@@ -29,8 +29,8 @@ export type ISystemConfig = {
   preview_max_memory: number;
   preview_max_filesize_image: number;
 
-  'memories.public_full_res_on_zoom': boolean;
-  'memories.public_full_res_always': boolean;
+  'memories.global_full_res_on_zoom': boolean;
+  'memories.global_full_res_always': boolean;
 };
 
 export type IBinaryStatus = 'ok' | 'not_found' | 'not_executable' | 'test_ok' | string;

--- a/src/components/admin/sections/FileSupport.vue
+++ b/src/components/admin/sections/FileSupport.vue
@@ -64,24 +64,34 @@
     />
 
     <br />
-    {{ t('memories', 'You can set the image viewer to always request a full size image when an image is opened for public folders (there is seperate user setting for logged in users).') }}
-    {{ t('memories', 'This is not recommended if the images require transcoding (i.e. heic images) because it will cause a large amount of CPU usage.') }}
+    {{
+      t(
+        'memories',
+        'You can set the image viewer to always request a full size image when an image is opened, or to open the full size image when an image is zoomed. Users can override this setting.'
+      )
+    }}
+    {{
+      t(
+        'memories',
+        'Always loading the full size image is not recommended if the images require transcoding (i.e. heic images) because it will cause a large amount of CPU usage.'
+      )
+    }}
     <br />
 
     <NcCheckboxRadioSwitch
-      :checked.sync="config['memories.public_full_res_on_zoom']"
-      @update:checked="update('memories.public_full_res_on_zoom',)"
+      :checked.sync="config['memories.global_full_res_on_zoom']"
+      @update:checked="update('memories.global_full_res_on_zoom')"
       type="switch"
     >
-      {{ t('memories', 'Load full size image on zoom for public folders') }}
+      {{ t('memories', 'Load full size image on zoom') }}
     </NcCheckboxRadioSwitch>
 
     <NcCheckboxRadioSwitch
-      :checked.sync="config['memories.public_full_res_always']"
-      @update:checked="update('memories.public_full_res_always',)"
+      :checked.sync="config['memories.global_full_res_always']"
+      @update:checked="update('memories.global_full_res_always')"
       type="switch"
     >
-      {{ t('memories', 'Always load full size image for public folders') }}
+      {{ t('memories', 'Always load full size image') }}
     </NcCheckboxRadioSwitch>
   </div>
 </template>

--- a/src/components/admin/sections/FileSupport.vue
+++ b/src/components/admin/sections/FileSupport.vue
@@ -62,6 +62,27 @@
       :value="String(config['preview_max_filesize_image'])"
       @change="update('preview_max_filesize_image', Number($event.target.value))"
     />
+
+    <br />
+    {{ t('memories', 'You can set the image viewer to always request a full size image when an image is opened for public folders (there is seperate user setting for logged in users).') }}
+    {{ t('memories', 'This is not recommended if the images require transcoding (i.e. heic images) because it will cause a large amount of CPU usage.') }}
+    <br />
+
+    <NcCheckboxRadioSwitch
+      :checked.sync="config['memories.public_full_res_on_zoom']"
+      @update:checked="update('memories.public_full_res_on_zoom',)"
+      type="switch"
+    >
+      {{ t('memories', 'Load full size image on zoom for public folders') }}
+    </NcCheckboxRadioSwitch>
+
+    <NcCheckboxRadioSwitch
+      :checked.sync="config['memories.public_full_res_always']"
+      @update:checked="update('memories.public_full_res_always',)"
+      type="switch"
+    >
+      {{ t('memories', 'Always load full size image for public folders') }}
+    </NcCheckboxRadioSwitch>
   </div>
 </template>
 

--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -797,7 +797,10 @@ export default defineComponent({
         : photo.flag & this.c.FLAG_IS_LOCAL
         ? nativex.API.IMAGE_FULL(photo.fileid)
         : API.IMAGE_DECODABLE(photo.fileid, photo.etag);
-      const fullLoadCond = this.config.full_res_always ? 'always' : this.config.full_res_on_zoom ? 'zoom' : 'never';
+
+      const fullResOnZoom = this.routeIsPublic ? this.config.public_full_res_on_zoom : this.config.full_res_on_zoom;
+      const fullResAlways = this.routeIsPublic ? this.config.public_full_res_always : this.config.full_res_always;
+      const fullLoadCond = fullResAlways ? 'always' : fullResOnZoom ? 'zoom' : 'never';
 
       return {
         src: previewUrl,

--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -798,8 +798,12 @@ export default defineComponent({
         ? nativex.API.IMAGE_FULL(photo.fileid)
         : API.IMAGE_DECODABLE(photo.fileid, photo.etag);
 
-      const fullResOnZoom = this.routeIsPublic ? this.config.public_full_res_on_zoom : this.config.full_res_on_zoom;
-      const fullResAlways = this.routeIsPublic ? this.config.public_full_res_always : this.config.full_res_always;
+      const fullResOnZoom = this.config.override_global_full_res
+        ? this.config.full_res_on_zoom
+        : this.config.global_full_res_on_zoom;
+      const fullResAlways = this.config.override_global_full_res
+        ? this.config.full_res_always
+        : this.config.global_full_res_always;
       const fullLoadCond = fullResAlways ? 'always' : fullResOnZoom ? 'zoom' : 'never';
 
       return {

--- a/src/mixins/UserConfig.ts
+++ b/src/mixins/UserConfig.ts
@@ -1,13 +1,15 @@
-import axios from '@nextcloud/axios';
 import { emit, subscribe, unsubscribe } from '@nextcloud/event-bus';
+
 import { API } from '../services/API';
-import { defineComponent } from 'vue';
 import { IConfig } from '../types';
+import axios from '@nextcloud/axios';
+import { defineComponent } from 'vue';
 import staticConfig from '../services/static-config';
 
 const eventName = 'memories:user-config-changed';
 const localSettings: (keyof IConfig)[] = [
   'square_thumbs',
+  'override_global_full_res',
   'full_res_on_zoom',
   'full_res_always',
   'show_face_rect',

--- a/src/services/static-config.ts
+++ b/src/services/static-config.ts
@@ -117,13 +117,14 @@ class StaticConfig {
       enable_top_memories: true,
 
       square_thumbs: false,
+      override_global_full_res: false,
       full_res_on_zoom: true,
       full_res_always: false,
       show_face_rect: false,
       album_list_sort: 1,
 
-      public_full_res_on_zoom: true,
-      public_full_res_always: false,
+      global_full_res_on_zoom: true,
+      global_full_res_always: false,
     };
 
     for (const key in config) {

--- a/src/services/static-config.ts
+++ b/src/services/static-config.ts
@@ -1,12 +1,13 @@
-import axios from '@nextcloud/axios';
-import { showInfo, showError } from '@nextcloud/dialogs';
-import { API } from './API';
-import { IConfig } from '../types';
-import { getBuilder } from '@nextcloud/browser-storage';
-import { translate as t } from '@nextcloud/l10n';
 import * as utils from './Utils';
 
+import { showError, showInfo } from '@nextcloud/dialogs';
+
+import { API } from './API';
+import { IConfig } from '../types';
 import type Storage from '@nextcloud/browser-storage/dist/storage';
+import axios from '@nextcloud/axios';
+import { getBuilder } from '@nextcloud/browser-storage';
+import { translate as t } from '@nextcloud/l10n';
 
 class StaticConfig {
   private config: IConfig | null = null;
@@ -120,6 +121,9 @@ class StaticConfig {
       full_res_always: false,
       show_face_rect: false,
       album_list_sort: 1,
+
+      public_full_res_on_zoom: true,
+      public_full_res_always: false,
     };
 
     for (const key in config) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -252,10 +252,11 @@ export type IConfig = {
   enable_top_memories: boolean;
 
   square_thumbs: boolean;
+  override_global_full_res: boolean;
   full_res_on_zoom: boolean;
   full_res_always: boolean;
-  public_full_res_on_zoom: boolean;
-  public_full_res_always: boolean;
+  global_full_res_on_zoom: boolean;
+  global_full_res_always: boolean;
   show_face_rect: boolean;
   album_list_sort: 1 | 2;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,8 @@ export type IConfig = {
   square_thumbs: boolean;
   full_res_on_zoom: boolean;
   full_res_always: boolean;
+  public_full_res_on_zoom: boolean;
+  public_full_res_always: boolean;
   show_face_rect: boolean;
   album_list_sort: 1 | 2;
 };


### PR DESCRIPTION
Add seperate full res configuration for public shares to the admin settings. 

Fixes: https://github.com/pulsejet/memories/issues/662