### PR TITLE
Memories metadata: Add support to Face Recognition

### DIFF
--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -352,7 +352,10 @@ export default defineComponent({
     },
 
     people(): IFace[] {
-      return this.baseInfo?.clusters?.recognize ?? [];
+      if (this.routeIsFaceRecognition)
+        return this.baseInfo?.clusters?.facerecognition ?? [];
+      else
+        return this.baseInfo?.clusters?.recognize ?? [];
     },
   },
 
@@ -367,6 +370,7 @@ export default defineComponent({
       const clusters = [
         this.config.albums_enabled ? 'albums' : null,
         this.config.recognize_enabled ? 'recognize' : null,
+        this.config.facerecognition_enabled ? 'facerecognition' : null,
       ]
         .filter((c) => c)
         .join(',');

--- a/src/mixins/GlobalMixin.ts
+++ b/src/mixins/GlobalMixin.ts
@@ -31,6 +31,9 @@ export default defineComponent({
     routeIsRecognizeUnassigned(): boolean {
       return this.routeIsRecognize && this.$route.params.name === constants.FACE_NULL;
     },
+    routeIsFaceRecognition(): boolean {
+      return this.$route.name === 'facerecognition';
+    },
     routeIsArchive(): boolean {
       return this.$route.name === 'archive';
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,7 @@ export interface IImageInfo {
   clusters?: {
     albums?: IAlbum[];
     recognize?: IFace[];
+    facerecognition?: IFace[];
   };
 }
 

--- a/src/vue-globals.d.ts
+++ b/src/vue-globals.d.ts
@@ -17,6 +17,7 @@ declare module 'vue' {
     routeIsPeople: boolean;
     routeIsRecognize: boolean;
     routeIsRecognizeUnassigned: boolean;
+    routeIsFaceRecognition: boolean;
     routeIsArchive: boolean;
     routeIsPlaces: boolean;
     routeIsMap: boolean;


### PR DESCRIPTION
I find the new approach interesting, and I want to use it.

Also I am considering hiding my People sidebar inside memories.

To minimize changes, still prioritize Recognize (At least until we're on equal terms), except when we're on the Face Recognition filter.