### PR TITLE
Add per-group and skip cleanup options

### DIFF
--- a/lib/Command/Index.php
+++ b/lib/Command/Index.php
@@ -29,7 +29,6 @@ use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
-use OCP\IGroup;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -215,12 +214,12 @@ class Index extends Command
             }
         } elseif ($gid = $this->opts->group) {
             if ($group = $this->groupManager->get($gid)) {
-                $this->output->writeln("<error>Group {$gid} not found</error>");
-            } else {
                 foreach ($group->getUsers() as $user) {
                     $closure($user);
-                }
-            }
+                }            
+        } else {
+            $this->output->writeln("<error>Group {$gid} not found</error>");
+        }
         } else {
             $this->userManager->callForSeenUsers(static fn (IUser $user) => $closure($user));
         }

--- a/lib/Command/Index.php
+++ b/lib/Command/Index.php
@@ -27,7 +27,9 @@ use OCA\Memories\Db\TimelineWrite;
 use OCA\Memories\Service;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IGroup;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,6 +42,8 @@ class IndexOpts
     public bool $clear = false;
     public ?string $user = null;
     public ?string $folder = null;
+    public ?string $group = null;
+    public bool $skipCleanup = false;
 
     public function __construct(InputInterface $input)
     {
@@ -47,6 +51,8 @@ class IndexOpts
         $this->clear = (bool) $input->getOption('clear');
         $this->user = $input->getOption('user');
         $this->folder = $input->getOption('folder');
+        $this->skipCleanup = $input->getOption('skip-cleanup');
+        $this->group = $input->getOption('group');
     }
 }
 
@@ -56,6 +62,7 @@ class Index extends Command
     protected array $sizes;
 
     protected IUserManager $userManager;
+    protected IGroupManager $groupManager;
     protected IRootFolder $rootFolder;
     protected IConfig $config;
     protected Service\Index $indexer;
@@ -71,6 +78,7 @@ class Index extends Command
     public function __construct(
         IRootFolder $rootFolder,
         IUserManager $userManager,
+        IGroupManager $groupManager,
         IConfig $config,
         Service\Index $indexer,
         TimelineWrite $timelineWrite
@@ -78,6 +86,7 @@ class Index extends Command
         parent::__construct();
 
         $this->userManager = $userManager;
+        $this->groupManager = $groupManager;
         $this->rootFolder = $rootFolder;
         $this->config = $config;
         $this->indexer = $indexer;
@@ -93,6 +102,8 @@ class Index extends Command
             ->addOption('folder', null, InputOption::VALUE_REQUIRED, 'Index only the specified folder (relative to the user\'s root)')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force refresh of existing index entries')
             ->addOption('clear', null, InputOption::VALUE_NONE, 'Clear all existing index entries')
+            ->addOption('skip-cleanup', null, InputOption::VALUE_NONE, 'Skip cleanup step')
+            ->addOption('group', 'g', InputOption::VALUE_REQUIRED, 'Index only specified group')
         ;
     }
 
@@ -125,7 +136,9 @@ class Index extends Command
             $this->runIndex();
 
             // Clean up the index
-            $this->indexer->cleanupStale();
+            if (!$this->opts->skipCleanup) {
+                $this->indexer->cleanupStale();
+            }
 
             return 0;
         } catch (\Exception $e) {
@@ -199,6 +212,14 @@ class Index extends Command
                 $closure($user);
             } else {
                 $this->output->writeln("<error>User {$uid} not found</error>");
+            }
+        } elseif ($gid = $this->opts->group) {
+            if ($group = $this->groupManager->get($gid)) {
+                $this->output->writeln("<error>Group {$gid} not found</error>");
+            } else {
+                foreach ($group->getUsers() as $user) {
+                    $closure($user);
+                }
             }
         } else {
             $this->userManager->callForSeenUsers(static fn (IUser $user) => $closure($user));


### PR DESCRIPTION
- For tens of thousands of users on an instance, running the index command is a must before enabling the app
- Sometimes,  need to re-run for a particular group so added `group`  option
- Also cleanup itself takes a few minutes and when running per-user, it wastes a lot of time, so added `skip-cleanup` option that defaults to `false`