### PR TITLE
Readme add required programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Memories is a _batteries-included_ photo management solution for Nextcloud with 
 ## 🏗 Development Setup
 
 1. ☁ Clone this into your `custom_apps` folder of your Nextcloud.
-2. 📥 Install [Composer](https://getcomposer.org/) and [Node.js 18](https://nodejs.org)
+1. 📥 Install [Composer](https://getcomposer.org/) and [Node.js 18](https://nodejs.org)
 1. 👩‍💻 In a terminal, run the command `make dev-setup` to install the dependencies.
 1. 🏗 To build/watch the UI, run `make watch-js`. Lint-fix PHP with `make php-lint`.
 1. ✅ Enable the app through the app management of your Nextcloud.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Memories is a _batteries-included_ photo management solution for Nextcloud with 
 ## 🏗 Development Setup
 
 1. ☁ Clone this into your `custom_apps` folder of your Nextcloud.
+2. 📥 Install [Composer](https://getcomposer.org/) and [Node.js 18](https://nodejs.org)
 1. 👩‍💻 In a terminal, run the command `make dev-setup` to install the dependencies.
 1. 🏗 To build/watch the UI, run `make watch-js`. Lint-fix PHP with `make php-lint`.
 1. ✅ Enable the app through the app management of your Nextcloud.


### PR DESCRIPTION
This adds a step to the "development setup" part of the readme that defines which programs have to be installed before make dev-setup is run.

I added Composer and node.js 18 becaues that are the programs that I had to install, but it is possible, that more programs are needed. I'm also not completly sure if 18 is the correct version of node.js but as far as I can tell from the package.json it is.