### PR TITLE
Translate tag names

### DIFF
--- a/src/components/ClusterView.vue
+++ b/src/components/ClusterView.vue
@@ -82,6 +82,18 @@ export default defineComponent({
   },
 
   methods: {
+    translated_tag_name(first_item: ICluster,second_item: ICluster) : number  {
+      const first_item_translated = this.t("recognize", first_item.name) 
+      const second_item_translated = this.t("recognize", second_item.name) 
+      if (first_item_translated < second_item_translated) {
+        return -1;
+      }
+      if (first_item_translated > second_item_translated) {
+        return 1;
+      }  
+      return 0;
+    },
+
     async routeChange() {
       try {
         this.items = [];
@@ -94,7 +106,7 @@ export default defineComponent({
         if (this.routeIsAlbums) {
           this.items = await dav.getAlbums(this.config.album_list_sort);
         } else if (this.routeIsTags) {
-          this.items = await dav.getTags();
+          this.items = (await dav.getTags()).sort(this.translated_tag_name);
         } else if (this.routeIsPeople) {
           this.items = await dav.getFaceList(<any>this.$route.name);
         } else if (this.routeIsPlaces) {

--- a/src/components/top-matter/ClusterTopMatter.vue
+++ b/src/components/top-matter/ClusterTopMatter.vue
@@ -13,6 +13,7 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 
+import { translate as t } from '@nextcloud/l10n';
 import NcActions from '@nextcloud/vue/dist/Components/NcActions';
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton';
 import * as strings from '../../services/strings';
@@ -35,7 +36,7 @@ export default defineComponent({
     name(): string | null {
       switch (this.$route.name) {
         case 'tags':
-          return this.$route.params.name;
+          return t('recognize',this.$route.params.name);
         case 'places':
           return this.$route.params.name?.split('-').slice(1).join('-');
         default:


### PR DESCRIPTION
This Pull-Request contains two changes related to translation of tag names.
The first change fixes a Problem, that the title of tag detail pages like /apps/memories/tags/Frog wasn't translated even though the name of is Tag is translated on the overview page.
The second change sorts the Tags on the overview page in the correct order for the current language. Previously this was sorted by english names and the translated names were shown. 