### PR TITLE
Show number of pictures per place

### DIFF
--- a/lib/ClustersBackend/PlacesBackend.php
+++ b/lib/ClustersBackend/PlacesBackend.php
@@ -162,7 +162,7 @@ class PlacesBackend extends Backend
         $lang = Util::getUserLang();
         foreach ($places as &$row) {
             $row['osm_id'] = (int) $row['osm_id'];
-            $row['count'] = $marked ? 0 : (int) $row['count']; // the count is incorrect
+            $row['count'] = (int) $row['sub.count'];
             self::choosePlaceLang($row, $lang);
         }
 


### PR DESCRIPTION
This shows the number of pictures per place.
This function was previously disabled, if the parameter 'mark'
wasn't set to 0. I found no reason why this was the case.
