### PR TITLE
Temporary Album Search function added

### DIFF
--- a/src/components/top-matter/AlbumTopMatter.vue
+++ b/src/components/top-matter/AlbumTopMatter.vue
@@ -10,6 +10,16 @@
     <div class="name">{{ name }}</div>
 
     <div class="right-actions">
+      <!-- Search Bar-->
+      <div v-if="isAlbumList" class="search-bar-container">
+        <NcInputField
+          :value="searchQuery"
+          :placeholder="t('memories', 'Search')"
+          @input="searchQuery = $event.target.value"
+          @keyup.enter="sendSearchQuery(searchQuery)"
+        />
+      </div>
+
       <NcActions :forceMenu="true" v-if="isAlbumList">
         <template #icon>
           <SortIcon :size="20" />
@@ -100,6 +110,7 @@ import NcActions from '@nextcloud/vue/dist/Components/NcActions';
 import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton';
 import NcActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox';
 import NcActionRadio from '@nextcloud/vue/dist/Components/NcActionRadio';
+import NcInputField from '@nextcloud/vue/dist/Components/NcInputField';
 
 import axios from '@nextcloud/axios';
 
@@ -127,6 +138,7 @@ export default defineComponent({
     NcActionButton,
     NcActionCheckbox,
     NcActionRadio,
+    NcInputField,
 
     AlbumCreateModal,
     AlbumDeleteModal,
@@ -143,6 +155,11 @@ export default defineComponent({
   },
 
   mixins: [UserConfig],
+
+  created() {
+    // Reset the search query when the component is created
+    this.resetSearchQuery();
+  },
 
   computed: {
     refs() {
@@ -186,6 +203,18 @@ export default defineComponent({
       }
     },
 
+    resetSearchQuery() {
+      // Reset the search query to an empty string or default state
+      this.config.album_list_search = '';
+      // Update the setting to ensure consistency
+      this.updateSetting('album_list_search');
+    },
+
+    sendSearchQuery(query: string) {
+      this.config.album_list_search = query;
+      this.updateSetting('album_list_search');
+    },
+
     /**
      * Change the sorting order
      * 1 = date, 2 = name
@@ -197,3 +226,10 @@ export default defineComponent({
   },
 });
 </script>
+
+<style lang="scss" scoped>
+.search-bar-container {
+  // Such that the search bar is placed on the left side of the sort menu
+  display: inline-block;
+}
+</style>

--- a/src/mixins/UserConfig.ts
+++ b/src/mixins/UserConfig.ts
@@ -10,7 +10,13 @@ import type { IConfig } from '@typings';
 
 const eventName: keyof utils.BusEvent = 'memories:user-config-changed';
 
-const localSettings: (keyof IConfig)[] = ['square_thumbs', 'high_res_cond', 'show_face_rect', 'album_list_sort'];
+const localSettings: (keyof IConfig)[] = [
+  'square_thumbs',
+  'high_res_cond',
+  'show_face_rect',
+  'album_list_sort',
+  'album_list_search',
+];
 
 export default defineComponent({
   name: 'UserConfig',

--- a/src/services/dav/albums.ts
+++ b/src/services/dav/albums.ts
@@ -38,6 +38,12 @@ export async function getAlbums(fileid?: number) {
     data = data.filter((a) => !a.name.startsWith('.'));
   }
 
+  // Filter the response for the search term
+  const searchTerm = await staticConfig.get('album_list_search');
+  if (searchTerm) {
+    data = data.filter((a) => a.name.toLowerCase().includes(searchTerm.toLowerCase()));
+  }
+
   // Sort the response
   switch (await staticConfig.get('album_list_sort')) {
     case 2:

--- a/src/services/static-config.ts
+++ b/src/services/static-config.ts
@@ -145,6 +145,7 @@ class StaticConfig {
       high_res_cond: null,
       show_face_rect: false,
       album_list_sort: 1,
+      album_list_search: '',
     };
 
     const set = <K extends keyof IConfig, V extends IConfig[K]>(key: K, value: string | null) => {

--- a/src/typings/config.d.ts
+++ b/src/typings/config.d.ts
@@ -35,11 +35,13 @@ declare module '@typings' {
     // album settings
     sort_album_month: boolean;
     show_hidden_albums: boolean;
+    album_list_search: string;
 
     // local settings
     square_thumbs: boolean;
     high_res_cond: HighResCond | null;
     show_face_rect: boolean;
     album_list_sort: 1 | 2;
+    album_list_search: string;
   };
 }


### PR DESCRIPTION
Addresses #746
- Temporary search function, until unified search through nextcloud search function is available
- Very useful for hundreds of albums
- I tried to implement it without changing a lot, so simply added a new config value which can be used similar to the sorting values to trigger the filtering for search queries
- There are probably better ways to solve this

I really needed this feature, so I added it in this simple form until a proper solution is available. But I understand, if you would rather not accept temporary solutions :)

