### PR TITLE
android: show local files on Android 10 devices

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Memories"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
This fixes #1000 on my Android 10 device.

For reference, the error I was getting on loading a new local image is:
`Failed to read EXIF data: /storage/emulated/0/DCIM/Camera/FILENAME.jpg: open failed: EACCES (Permission denied)`

I was unable to test the impact on newer devices but I think it should be [fine](https://developer.android.com/training/data-storage/use-cases#opt-out-in-production-app):
> After you update your app to target Android 11 (API level 30), [the system ignores the requestLegacyExternalStorage attribute](https://developer.android.com/about/versions/11/privacy/storage#scoped-storage) when your app is running on Android 11 devices, so your app must be ready to support scoped storage and to [migrate app data](https://developer.android.com/training/data-storage/use-cases#migrate-legacy-storage) for users on those devices