### PR TITLE
android: show local files on older devices

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Memories"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/java/gallery/memories/service/ImageService.kt
+++ b/android/app/src/main/java/gallery/memories/service/ImageService.kt
@@ -7,6 +7,7 @@ import android.graphics.ImageDecoder
 import android.os.Build
 import android.provider.MediaStore
 import androidx.media3.common.util.UnstableApi
+import gallery.memories.mapper.SystemImage
 import java.io.ByteArrayOutputStream
 
 @UnstableApi class ImageService(private val mCtx: Context, private val query: TimelineQuery) {
@@ -19,11 +20,15 @@ import java.io.ByteArrayOutputStream
     fun getPreview(id: Long): ByteArray {
         val bitmap =
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val sysImgs = SystemImage.getByIds(mCtx, listOf(id))
+                if (sysImgs.isEmpty()) {
+                    throw Exception("Image not found")
+                }
+
+                val uri = sysImgs[0].uri
+
                 mCtx.contentResolver.loadThumbnail(
-                    ContentUris.withAppendedId(
-                        MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
-                        id
-                    ),
+                    uri,
                     android.util.Size(2048, 2048),
                     null
                 )


### PR DESCRIPTION
I found that the [previous PR](https://github.com/pulsejet/memories/pull/1118) was only one step to fixing the issue. Just like before, android:requestLegacyExternalStorage is needed for permission purposes, which fixes the EXIF data and full image on zoom. However, the thumbnail generation was still not working as the URI returned by ContentUris.withAppendedId was incorrect, so I used a different approach to get the correct URI.

I could not easily test on newer devices but on my Android 10, this fixes #1000.