### PR TITLE
fix: Ensure read-write permissions for devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,10 +5,10 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./custom_apps:/var/www/html/custom_apps
-      - ../:/var/www/html/custom_apps/memories
-      - ./config:/var/www/html/config
-      - ./data:/var/www/html/data
+      - ./custom_apps:/var/www/html/custom_apps:rw
+      - ../:/var/www/html/custom_apps/memories:rw
+      - ./config:/var/www/html/config:rw
+      - ./data:/var/www/html/data:rw
     ports:
       - 9080:80
     image: nextcloud


### PR DESCRIPTION
It fixes my problem when I tried to develop something using devcontainer and GitHub Codespaces.


![obraz](https://github.com/pulsejet/memories/assets/45544416/3f76ba12-3a6a-4a9c-ba60-ce7980757334)
