### PR TITLE
Android: Added onSaveInstanceState

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.Memories.NoActionBar"
-            android:configChanges="orientation|screenSize|screenLayout">
+            android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|screenLayout|fontScale|uiMode|orientation|density|screenSize|smallestScreenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.Memories.NoActionBar"
-            android:configChanges="orientation|screenSize">
+            android:configChanges="orientation|screenSize|screenLayout">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -91,27 +91,14 @@ class MainActivity : AppCompatActivity() {
         // Initialize handlers
         initializeIntentHandlers()
 
-        val url = savedInstanceState?.getString("currentUrl")
-
         // Load JavaScript
-        if (url != null) { // Restore previous state
-            initializeWebView(url)
-
-        } else {
-            initializeWebView()
-
-        }
+        initializeWebView()
 
         // Destroy video after 1 seconds (workaround for video not showing on first load)
         binding.videoView.postDelayed({
             binding.videoView.alpha = 1.0f
             binding.videoView.visibility = View.GONE
         }, 1000)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        outState.putString("currentUrl", binding.webview.url)
     }
 
     override fun onDestroy() {
@@ -186,7 +173,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
-    private fun initializeWebView(url: String? = null) {
+    private fun initializeWebView() {
         // Intercept local APIs
         binding.webview.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(
@@ -290,15 +277,7 @@ class MainActivity : AppCompatActivity() {
 
         // Welcome page or actual app
         nativex.account.refreshCredentials()
-
-        val isApp: Boolean
-        // Load given URL if provided, should be from previous state, no error expected
-        if (url != null) {
-            binding.webview.loadUrl(url)
-            isApp = false
-        } else {
-            isApp = loadDefaultUrl()
-        }
+        val isApp = loadDefaultUrl()
 
         // Start version check if loaded account
         if (isApp) {

--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -87,8 +87,16 @@ class MainActivity : AppCompatActivity() {
         // Initialize handlers
         initializeIntentHandlers()
 
+        val url = savedInstanceState?.getString("currentUrl")
+
         // Load JavaScript
-        initializeWebView()
+        if (url != null) { // Restore previous state
+            initializeWebView(url)
+
+        } else {
+            initializeWebView()
+
+        }
 
         // Destroy video after 1 seconds (workaround for video not showing on first load)
         binding.videoView.postDelayed({
@@ -169,7 +177,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     @SuppressLint("SetJavaScriptEnabled", "ClickableViewAccessibility")
-    private fun initializeWebView() {
+    private fun initializeWebView(url: String? = null) {
         // Intercept local APIs
         binding.webview.webViewClient = object : WebViewClient() {
             override fun shouldOverrideUrlLoading(
@@ -273,7 +281,15 @@ class MainActivity : AppCompatActivity() {
 
         // Welcome page or actual app
         nativex.account.refreshCredentials()
-        val isApp = loadDefaultUrl()
+
+        val isApp: Boolean
+        // Load given URL if provided, should be from previous state, no error expected
+        if (url != null) {
+            binding.webview.loadUrl(url)
+            isApp = false
+        } else {
+            isApp = loadDefaultUrl()
+        }
 
         // Start version check if loaded account
         if (isApp) {

--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -75,6 +75,10 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        // Set fullscreen mode if in landscape
+        val orientation = resources.configuration.orientation
+        setFullscreen(orientation == Configuration.ORIENTATION_LANDSCAPE)
+
         // Restore last known look
         restoreTheme()
 

--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -105,11 +105,16 @@ class MainActivity : AppCompatActivity() {
         }, 1000)
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString("currentUrl", binding.webview.url)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
-        binding.webview.removeAllViews();
+        binding.webview.removeAllViews()
         binding.coordinator.removeAllViews()
-        binding.webview.destroy();
+        binding.webview.destroy()
         nativex.destroy()
     }
 
@@ -140,7 +145,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+        if (event.action == KeyEvent.ACTION_DOWN) {
             when (keyCode) {
                 KeyEvent.KEYCODE_BACK -> {
                     if (binding.webview.canGoBack()) {
@@ -276,7 +281,7 @@ class MainActivity : AppCompatActivity() {
         if (BuildConfig.DEBUG) {
             Toast.makeText(this, "Debugging enabled", Toast.LENGTH_SHORT).show()
             binding.webview.clearCache(true)
-            WebView.setWebContentsDebuggingEnabled(true);
+            WebView.setWebContentsDebuggingEnabled(true)
         }
 
         // Welcome page or actual app
@@ -304,7 +309,7 @@ class MainActivity : AppCompatActivity() {
         if (host != null) return true
 
         // Load welcome page
-        binding.webview.loadUrl("file:///android_asset/welcome.html");
+        binding.webview.loadUrl("file:///android_asset/welcome.html")
         return false
     }
 


### PR DESCRIPTION
For some reason, I wasn´t able to find out why, on my phone (Pixel 7, android 14) is main activity always recreated when screen is rotated, and app always forget in which state it was. I was not able to replicate this behavior in android studio emulator, which is weird. It is really annoying so I decided  to add feature to restore MainActivity from previous state.

For the same reason no full screen setting (hide status bar) was called so I added it to onCreate function. All edits would be called once on devices without this problem, which should be fine, and this will work as back up for devices which do have same problem. 

Bonus is, that this will work every time, that for example split screen should now work better (App will not "restart").