### PR TITLE
Display album metadata (location field, collaborators)

### DIFF
--- a/lib/Db/AlbumsQuery.php
+++ b/lib/Db/AlbumsQuery.php
@@ -88,12 +88,20 @@ class AlbumsQuery
         // FETCH all albums
         $albums = $query->executeQuery()->fetchAll();
 
+        // Additionally fetch all shared album ids
+        $queryShared = $this->connection->getQueryBuilder();
+        $queryShared->select('album_id')->from($this->collaboratorsTable());
+        $shared_ids = array_map(function($row) {
+            return (int)$row['album_id'];
+        }, $queryShared->executeQuery()->fetchAll());
+
         // Post process
         foreach ($albums as &$row) {
             $row['cluster_id'] = $row['user'].'/'.$row['name'];
             $row['album_id'] = (int) $row['album_id'];
             $row['created'] = (int) $row['created'];
             $row['last_added_photo'] = (int) $row['last_added_photo'];
+            $row['shared'] = in_array($row['album_id'], $shared_ids, true);
         }
 
         return $albums;

--- a/src/components/frame/Cluster.vue
+++ b/src/components/frame/Cluster.vue
@@ -98,6 +98,8 @@ export default defineComponent({
             user: this.data.user_display || this.data.user,
           });
           text = `${text} / ${sharer}`;
+        } else if (this.data.shared) {
+          text += ' | ' + this.t('memories', 'Shared Album');
         }
 
         return text;

--- a/src/components/modal/AlbumsList.vue
+++ b/src/components/modal/AlbumsList.vue
@@ -115,6 +115,8 @@ export default defineComponent({
           this.t('memories', 'Shared by {user}', {
             user: album.user_display || album.user,
           });
+      } else if (album.shared) {
+        text += ' | ' + this.t('memories', 'Shared Album');
       }
 
       return text;

--- a/src/components/top-matter/AlbumDynamicTopMatter.vue
+++ b/src/components/top-matter/AlbumDynamicTopMatter.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="album-dtm">
+    <div v-if="viewsubTitle" class="subtitle">
+      <MapMarkerOutlineIcon class="icon"></MapMarkerOutlineIcon>
+      <span>{{ viewsubTitle }}</span>
+    </div>
+
+    <div class="avatars">
+      <NcAvatar
+        v-for="c of collaborators"
+        :key="c"
+        :user="c"
+        :displayName="c"
+        :showUserStatus="false"
+        :disableMenu="false"
+      />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+import * as dav from '@services/dav';
+
+import MapMarkerOutlineIcon from 'vue-material-design-icons/MapMarkerOutline.vue';
+const NcAvatar = () => import('@nextcloud/vue/dist/Components/NcAvatar.js');
+
+type Collaborator = {
+  id: string;
+  label: string;
+};
+
+export default defineComponent({
+  name: 'AlbumDynamicTopMatter',
+
+  components: {
+    MapMarkerOutlineIcon,
+    NcAvatar,
+  },
+
+  data: () => ({
+    album: null as any,
+  }),
+
+  computed: {
+
+    collaborators(): string[] {
+      if (this.album) {
+        return [this.$route.params.user, ...this.album.collaborators.map((c: Collaborator) => c.id)];
+      }
+      return [];
+    },
+
+    /** Get view subtitle for dynamic top matter */
+    viewsubTitle(): string {
+      if (this.album) {
+        return this.album.location ?? String();
+      }
+      return String();
+    },
+  },
+
+  methods: {
+    async refresh(): Promise<boolean> {
+      try {
+        this.album = await dav.getAlbum(this.$route.params.user, this.$route.params.name);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    },
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.album-dtm {
+  > .subtitle {
+    font-size: 1.1em;
+    line-height: 1.2em;
+    margin-top: 0.5em;
+    color: var(--color-text-lighter);
+    display: flex;
+    padding-left: 10px;
+  }
+
+  .icon {
+    margin-right: 5px;
+  }
+
+  > .avatars {
+    line-height: 1.2em;
+    margin-top: 0.5em;
+    padding-left: 10px;
+  }
+}
+</style>

--- a/src/components/top-matter/DynamicTopMatter.vue
+++ b/src/components/top-matter/DynamicTopMatter.vue
@@ -10,10 +10,10 @@ import { defineComponent, type Component } from 'vue';
 
 import UserMixin from '@mixins/UserConfig';
 
+import AlbumDynamicTopMatter from './AlbumDynamicTopMatter.vue';
 import FolderDynamicTopMatter from './FolderDynamicTopMatter.vue';
 import PlacesDynamicTopMatterVue from './PlacesDynamicTopMatter.vue';
 import OnThisDay from './OnThisDay.vue';
-
 import * as strings from '@services/strings';
 
 // Auto-hide top header on public shares if redundant
@@ -40,6 +40,8 @@ export default defineComponent({
         return FolderDynamicTopMatter;
       } else if (this.routeIsPlaces) {
         return PlacesDynamicTopMatterVue;
+      } else if (this.routeIsAlbums) {
+        return AlbumDynamicTopMatter;
       } else if (this.routeIsBase && this.config.enable_top_memories) {
         return OnThisDay;
       }

--- a/src/typings/cluster.d.ts
+++ b/src/typings/cluster.d.ts
@@ -46,6 +46,8 @@ declare module '@typings' {
     last_added_photo_etag: string;
     /** Record ID of the latest update */
     update_id: number;
+    /** Album is shared with other users */
+    shared: boolean;
   }
 
   export interface IFace extends ICluster {


### PR DESCRIPTION
This is a draft PR that attempts to improve memories' albums view by displaying essential metadata.

## Added UI

First 2 commits attempt to display the "shared" status of an album. This makes it easier to see which albums are private or not and which users have access/contributed to a specific album.

1. show whether an album is shared in the albums overview listings (i.e., add a "shared" keyword, similar to how it's done for Google Photos and [nc-photos](https://gitlab.com/nkming2/nc-photos)).  (aside: not sure what is desired re translations, but I went for "Shared Album" for now as that is already in the translations currently; adding a more brief "Shared" translation keyword would probably be even more concise in the UI though..)
2. display the avatars of album collaborators above the album contents timeline (again similar to Google Photos)

Lastly:

3. display the "location" field already optionally provided by the user for every album (ie similar to how it's done already in Nextcloud Photos).

Point (3) above is especially lacking as the existing UI allows the user to record a "location" field but this is never displayed AFAIS..

## Screenshots

![Screenshot from 2024-07-17 00-46-25](https://github.com/user-attachments/assets/77296981-c3c5-4ca5-a7d2-d15edf0ad725)
![Screenshot from 2024-07-17 00-50-15](https://github.com/user-attachments/assets/e25375fb-390a-4ae1-98b3-35ffcc277e57)

## Remaining Issues

This is my first attempt at diving into Nextcloud/PHP/Vue/etc so feedback is greatly appreciated!

~A remaining problem with the current code is that points (2-3) above require the metadata to be in `$route.params`, but it seems like one can only put it there when navigating to the album page via the albums cluster listing (cf. my hack in `getClusterLinkTarget` in `clusters.ts`). Thus, the added metadata (2nd screenshot) is not displayed when navigating to the album directly via a link (or reloading the page). This is clearly undesirable, but I couldn't figure out how to get around that with my limited understanding of Vue.~

~@pulsejet or others: could you give some directions on what is the proper way to get to the `IAlbum.location` and other properties from within the DynamicTopMatter? I'd be happy to work further on this PR to refine the functionality.~

