### PR TITLE
feat: Add username label on shared photos

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -56,6 +56,8 @@ return [
         ['name' => 'Map#clusters', 'url' => '/api/map/clusters', 'verb' => 'GET'],
         ['name' => 'Map#init', 'url' => '/api/map/init', 'verb' => 'GET'],
 
+        ['name' => 'Uid#name', 'url' => '/api/uid/name/{id}', 'verb' => 'GET'],
+
         ['name' => 'Archive#archive', 'url' => '/api/archive/{id}', 'verb' => 'PATCH'],
 
         ['name' => 'Image#preview', 'url' => '/api/image/preview/{id}', 'verb' => 'GET'],

--- a/lib/Controller/UidController.php
+++ b/lib/Controller/UidController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Varun Patil <radialapps@gmail.com>
+ * @author Varun Patil <radialapps@gmail.com>
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Memories\Controller;
+
+use OCA\Memories\Util;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+
+class UidController extends GenericApiController
+{
+    /**
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     *
+     * @PublicPage
+     *
+     * Get display name for a Nextcloud user id
+     *
+     * @param string fileid
+     */
+    public function name(
+        string $uid,
+    ): Http\Response {
+        return Util::guardEx(static function () use ($uid) {
+            $userManager = \OC::$server->get(\OCP\IUserManager::class);
+            $user = $userManager->get($uid);
+
+            return new JSONResponse([
+                'user_display' => $user ? $user->getDisplayName() : null,
+            ], Http::STATUS_OK);
+        });
+    }
+}

--- a/lib/Db/TimelineQuery.php
+++ b/lib/Db/TimelineQuery.php
@@ -25,6 +25,7 @@ class TimelineQuery
         'f.etag', 'f.name AS basename',
         'f.size', 'm.epoch', // auid
         'mimetypes.mimetype',
+        'm.uid',
     ];
 
     protected ?TimelineRoot $_root = null; // cache

--- a/lib/Db/TimelineQueryDays.php
+++ b/lib/Db/TimelineQueryDays.php
@@ -7,6 +7,7 @@ namespace OCA\Memories\Db;
 use OCA\Memories\ClustersBackend;
 use OCA\Memories\Exif;
 use OCA\Memories\Settings\SystemConfig;
+use OCA\Memories\Util;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
@@ -313,6 +314,10 @@ trait TimelineQueryDays
         }
         if (!$row['liveid']) {
             unset($row['liveid']);
+        }
+
+        if ($row['uid'] === Util::getUID()) {
+            unset($row['uid']);
         }
 
         // Favorite field, may not be present

--- a/lib/Db/TimelineQuerySingleItem.php
+++ b/lib/Db/TimelineQuerySingleItem.php
@@ -45,7 +45,7 @@ trait TimelineQuerySingleItem
     public function getInfoById(int $id, bool $basic): array
     {
         $qb = $this->connection->getQueryBuilder();
-        $qb->select('fileid', 'dayid', 'datetaken', 'w', 'h')
+        $qb->select('fileid', 'dayid', 'datetaken', 'w', 'h', 'uid')
             ->from('memories')
             ->where($qb->expr()->eq('fileid', $qb->createNamedParameter($id, \PDO::PARAM_INT)))
         ;
@@ -63,6 +63,7 @@ trait TimelineQuerySingleItem
             'w' => (int) $row['w'],
             'h' => (int) $row['h'],
             'datetaken' => Util::sqlUtcToTimestamp($row['datetaken']),
+            'uid' => $row['uid'],
         ];
 
         // Return if only basic info is needed

--- a/lib/Db/TimelineWrite.php
+++ b/lib/Db/TimelineWrite.php
@@ -72,6 +72,7 @@ class TimelineWrite
         // Get parameters
         $mtime = $file->getMtime();
         $fileId = $file->getId();
+        $uid = $file->getOwner()?->getUID();
         $isvideo = Index::isVideo($file);
 
         // Get previous row
@@ -172,6 +173,7 @@ class TimelineWrite
             'orphan' => $query->createNamedParameter(false, IQueryBuilder::PARAM_BOOL),
             'buid' => $query->createNamedParameter($buid, IQueryBuilder::PARAM_STR),
             'parent' => $query->createNamedParameter($file->getParent()->getId(), IQueryBuilder::PARAM_INT),
+            'uid' => $query->createNamedParameter($uid, IQueryBuilder::PARAM_STR),
         ];
 
         // There is no easy way to UPSERT in standard SQL

--- a/lib/Migration/Version800001Date20241026171056.php
+++ b/lib/Migration/Version800001Date20241026171056.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2023 Varun Patil <radialapps@gmail.com>
+ * @author Varun Patil <radialapps@gmail.com>
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Memories\Migration;
+
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * FIXME Auto-generated migration step: Please modify to your needs!
+ */
+class Version800001Date20241026171056 extends SimpleMigrationStep
+{
+    public function __construct(private IDBConnection $dbc) {}
+
+    /**
+     * @param \Closure(): ISchemaWrapper $schemaClosure
+     */
+    public function preSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {}
+
+    /**
+     * @param \Closure(): ISchemaWrapper $schemaClosure
+     */
+    public function changeSchema(IOutput $output, \Closure $schemaClosure, array $options): ?ISchemaWrapper
+    {
+        /** @var ISchemaWrapper $schema */
+        $schema = $schemaClosure();
+        if (!$schema->hasTable('memories')) {
+            throw new \Exception('Memories table does not exist');
+        }
+
+        $table = $schema->getTable('memories');
+
+        if (!$table->hasColumn('uid')) {
+            $table->addColumn('uid', 'string', [
+                'notnull' => false,
+                'length' => 64,
+            ]);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @param \Closure(): ISchemaWrapper $schemaClosure
+     */
+    public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void
+    {
+        // create database triggers; this will never throw
+        \OCA\Memories\Db\AddMissingIndices::createFilecacheTriggers($output);
+
+        // migrate uid values from filecache
+        try {
+            $output->info('Migrating values for uid from filecache');
+
+            $platform = $this->dbc->getDatabasePlatform();
+
+            // copy existing parent values from filecache
+            if (preg_match('/mysql|mariadb/i', $platform::class)) {
+                $this->dbc->executeQuery(
+                    'UPDATE *PREFIX*memories AS m
+                    JOIN *PREFIX*filecache AS f ON f.fileid = m.fileid
+                    JOIN *PREFIX*storages AS s ON f.storage = s.numeric_id
+                    SET m.uid = SUBSTRING_INDEX(s.id, \'::\', -1)
+                    WHERE s.id LIKE \'home::%\'
+                    ',
+                );
+            } elseif (preg_match('/postgres/i', $platform::class)) {
+                $this->dbc->executeQuery(
+                    'UPDATE *PREFIX*memories AS m
+                     SET uid = split_part(s.id, \'::\', 2)
+                     FROM *PREFIX*filecache AS f
+                     JOIN *PREFIX*storages AS s ON f.storage = s.numeric_id
+                     WHERE f.fileid = m.fileid
+                     AND s.id LIKE \'home::%\'
+                     ',
+                );
+            } elseif (preg_match('/sqlite/i', $platform::class)) {
+                $this->dbc->executeQuery(
+                    'UPDATE memories AS m
+                     SET uid = SUBSTR(s.id, INSTR(s.id, \'::\') + 2)
+                     FROM filecache AS f
+                     JOIN storages AS s ON f.storage = s.numeric_id
+                     WHERE f.fileid = m.fileid
+                     AND s.id LIKE \'home::%\'
+                     ',
+                );
+            } else {
+                throw new \Exception('Unsupported '.$platform::class);
+            }
+
+            $output->info('Values for uid migrated successfully');
+        } catch (\Exception $e) {
+            $output->warning('Failed to copy uid values from fileid: '.$e->getMessage());
+            $output->warning('Please run occ memories:index -f');
+        }
+    }
+}

--- a/src/components/Metadata.vue
+++ b/src/components/Metadata.vue
@@ -17,6 +17,19 @@
       <AlbumsList class="albums" :albums="albums" />
     </div>
 
+    <div v-if="uid">
+      <div class="section-title">{{ t('memories', 'Shared By') }}</div>
+      <div class="top-field">
+        <div class="icon">
+          <NcAvatar key="uid" :user="uid" :showUserStatus="false" :size="24" />
+        </div>
+
+        <div class="text">
+          <span class="title">{{ userDisplay }}</span>
+        </div>
+      </div>
+    </div>
+
     <div class="section-title">{{ t('memories', 'Metadata') }}</div>
     <div v-for="field of topFields" :key="field.title" :class="`top-field top-field--${field.id}`">
       <div class="icon">
@@ -90,8 +103,9 @@ import TagIcon from 'vue-material-design-icons/Tag.vue';
 import * as utils from '@services/utils';
 import * as dav from '@services/dav';
 import { API } from '@services/API';
-
 import type { IAlbum, IFace, IImageInfo, IPhoto, IExif } from '@typings';
+
+const NcAvatar = () => import('@nextcloud/vue/dist/Components/NcAvatar.js');
 
 interface TopField {
   id?: string;
@@ -110,6 +124,7 @@ export default defineComponent({
     AlbumsList,
     Cluster,
     EditIcon,
+    NcAvatar,
   },
 
   mixins: [UserConfig],
@@ -120,6 +135,8 @@ export default defineComponent({
     exif: {} as IExif,
     baseInfo: {} as IImageInfo,
     error: false,
+    uid: null as string | null,
+    userDisplay: '',
 
     loading: 0,
     state: 0,
@@ -418,6 +435,11 @@ export default defineComponent({
       this.fileid = this.baseInfo.fileid;
       this.filename = this.baseInfo.basename;
       this.exif = this.baseInfo.exif ?? {};
+
+      // set user info
+      this.uid = this.baseInfo.uid ?? null;
+      if (this.uid == utils.uid) this.uid = null;
+      this.userDisplay = await utils.getUserDisplayName(this.uid);
 
       return this.baseInfo;
     },

--- a/src/components/frame/Photo.vue
+++ b/src/components/frame/Photo.vue
@@ -29,9 +29,14 @@
         </div>
       </div>
 
-      <div class="flag bottom-left">
+      <div class="flag bottom-right">
         <StarIcon :size="22" v-if="data.flag & c.FLAG_IS_FAVORITE" />
         <LocalIcon :size="22" v-if="data.flag & c.FLAG_IS_LOCAL" />
+      </div>
+
+      <div class="flag bottom-left">
+        <AccountMultipleIcon :size="22" v-if="data.uid" />
+        <span class="username" v-if="data.uid">{{ owner }}</span>
       </div>
 
       <div
@@ -81,6 +86,7 @@ import StarIcon from 'vue-material-design-icons/Star.vue';
 import VideoIcon from 'vue-material-design-icons/PlayCircleOutline.vue';
 import LocalIcon from 'vue-material-design-icons/CloudOff.vue';
 import RawIcon from 'vue-material-design-icons/Raw.vue';
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue';
 
 import type { IDay, IPhoto } from '@typings';
 import type XImg from '@components/XImg.vue';
@@ -96,6 +102,7 @@ export default defineComponent({
     StarIcon,
     LocalIcon,
     RawIcon,
+    AccountMultipleIcon,
   },
 
   props: {
@@ -126,6 +133,7 @@ export default defineComponent({
       requested: false,
     },
     faceSrc: null as string | null,
+    userDisplay: null as string | null,
   }),
 
   watch: {
@@ -171,6 +179,10 @@ export default defineComponent({
         return utils.getDurationStr(this.data.video_duration);
       }
       return null;
+    },
+
+    owner(): string {
+      return this.userDisplay ?? this.data.uid ?? '';
     },
 
     videoUrl(): string | null {
@@ -260,9 +272,14 @@ export default defineComponent({
       );
     },
 
+    async addUserDisplay() {
+      this.userDisplay = await utils.getUserDisplayName(this.data.uid ?? null);
+    },
+
     /** Post load tasks */
     load() {
       this.addFaceRect();
+      this.addUserDisplay();
     },
 
     /** Error in loading image */
@@ -415,6 +432,20 @@ $icon-size: $icon-half-size * 2;
     .p-outer.selected > & {
       transform: translate($icon-size, -$icon-size);
     }
+  }
+
+  &.bottom-right {
+    bottom: var(--icon-dist);
+    right: var(--icon-dist);
+    .p-outer.selected > & {
+      transform: translate($icon-size, -$icon-size);
+    }
+  }
+
+  > .username {
+    font-size: 0.75em;
+    font-weight: bold;
+    margin-left: 3px;
   }
 
   > .video {

--- a/src/services/API.ts
+++ b/src/services/API.ts
@@ -221,4 +221,8 @@ export class API {
   static MAP_INIT() {
     return tok(gen(`${BASE}/map/init`));
   }
+
+  static UID_NAME(uid: string) {
+    return tok(gen(`${BASE}/uid/name/{uid}`, { uid }));
+  }
 }

--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -6,3 +6,4 @@ export * from './helpers';
 export * from './dialog';
 export * from './event-bus';
 export * from './fragment';
+export * from './user';

--- a/src/services/utils/user.ts
+++ b/src/services/utils/user.ts
@@ -1,0 +1,19 @@
+import axios from '@nextcloud/axios';
+import { API } from '@services/API';
+import * as utils from '@services/utils';
+
+export async function getUserDisplayName(uid: string | null): Promise<string> {
+  if (!uid) return '';
+
+  // First look in cache
+  const cacheUrl = API.UID_NAME(uid);
+  const cache = await utils.getCachedData<string>(cacheUrl);
+  if (cache) return cache;
+
+  // Network request and update cache
+  const { data } = await axios.get(API.Q(cacheUrl, { uid }));
+  const name = data?.user_display ?? '';
+  utils.cacheData(cacheUrl, name);
+
+  return name;
+}

--- a/src/typings/data.d.ts
+++ b/src/typings/data.d.ts
@@ -99,6 +99,8 @@ declare module '@typings' {
 
     /** Stacked RAW photos */
     stackraw?: IPhoto[];
+
+    uid?: string;
   };
 
   export interface IImageInfo {
@@ -125,6 +127,8 @@ declare module '@typings' {
       recognize?: IFace[];
       facerecognition?: IFace[];
     };
+
+    uid?: string;
   }
 
   export interface IExif {


### PR DESCRIPTION
Fixes #955

I find this feature really lacking when sharing large albums and/or timelines with multiple people, so I had a shot at implementing this the other day. Currently looks as follows:

![Screenshot from 2024-08-10 21-26-00](https://github.com/user-attachments/assets/004e6aa3-3a2b-42e0-be4c-cdad9d89e6d2)

The nextcloud username is shown in the bottom left of the picture frame for all pictures that are not owned by the logged-in user, both in the Timeline and Albums view.

I had to extend the database scheme with an additional "owner" column that stores the owner UUID for every memories-indexed photo. This would probably require a `lib/Migration/` handler to amend existing rows; not sure how this is normally handled -- @pulsejet ?

Possible extensions include:

* displaying full user info (ie not just the nextcloud username) in the "metadata" pane
* filtered view for a dedicated "Shared with you" menu item cf #787 -- (one of the only features that Photos has that Memories doesn't..)