### PR TITLE
Update install.md with postgresql >=v15

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -24,7 +24,7 @@ Before installing Memories, make sure that the following requirements are met:
 
 1. Nextcloud 26 or later.
 1. PHP 8.0 or later.
-1. MySQL, MariaDB, or PostgreSQL database.
+1. MySQL, MariaDB, or PostgreSQL (>=v15) database.
 1. [Imagick](https://www.php.net/manual/en/book.imagick.php) PHP extension.
 1. [ffmpeg](https://ffmpeg.org/) and [ffprobe](https://ffmpeg.org/ffprobe.html) binaries.
 


### PR DESCRIPTION
to fix #1106 and #1309 

Nextcloud 30 still lists PostgreSQL 12/13/14/15/16 as recommended and still supports down to PostgreSQL 10.