### PR TITLE
Exif: dispatch nodeWrittenEvent

### DIFF
--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -6,6 +6,8 @@ namespace OCA\Memories;
 
 use OCA\Memories\AppInfo\Application;
 use OCA\Memories\Service\BinExt;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\File;
 
 class Exif
@@ -396,6 +398,12 @@ class Exif
         if (!$file->getStorage()->isLocal()) {
             $file->putContent(fopen($path, 'r')); // closes the handler
         }
+
+		// dispatch NodeWrittenEvent to trigger processing by other apps
+		try {
+			$eventDispatcher = \OCP\Server::get(IEventDispatcher::class);
+			$eventDispatcher->dispatchTyped(new NodeWrittenEvent($file));
+		} catch (\Exception) {}
 
         // Touch the file, triggering a reprocess through the hook
         $file->touch();


### PR DESCRIPTION
When metadata/EXIF data are written in Memories, the native Nextcloud metadata handling isn't triggered since $file->touch() alone doesn't propagate these changes. This PR adds dispatching of the nodeWritten event to ensure proper metadata synchronization. 
Most EXIF tags are not present in the metadata one gets with the native $file->getMetadata() anyway, but e.g. the important copyright tag is.
Also other apps might depend on this event to properly handle changes. 