### PR TITLE
Implement merge person/clusters on Face recognition backend. Part of …

### DIFF
--- a/src/components/modal/FaceMergeModal.vue
+++ b/src/components/modal/FaceMergeModal.vue
@@ -99,6 +99,20 @@ export default defineComponent({
         return;
       }
 
+      if (this.routeIsFaceRecognition) {
+        if (Number.isInteger(Number(newName))) {
+          showError(this.t('memories', 'You can only merge with a person with name'));
+          return;
+        }
+        await dav.faceRecognitionRenamePerson(name, newName);
+        await this.close();
+        await this.$router.replace({
+          name: 'facerecognition',
+          params: { user: face.user_id, name: newName },
+        });
+        return;
+      }
+
       try {
         // Get all files for current face
         let res = (await client.getDirectoryContents(`/recognize/${user}/faces/${name}`, { details: true })) as any;


### PR DESCRIPTION
…issue #285

Just try to make the patch as simple as possible without changing a single line of behavior in recognize.

The warning that you can only merge with named people is important, and while I personally don't understand why we would merge unnamed people, it is a feature that the recognize backend supports.