### PR TITLE
fix: autoplay successive live photos

### DIFF
--- a/src/components/viewer/PsLivePhoto.ts
+++ b/src/components/viewer/PsLivePhoto.ts
@@ -32,7 +32,7 @@ class LivePhotoContentSetup {
     const video = content.element?.querySelector('video');
     if (!video) return;
 
-    if (this.liveState.playing) {
+    if (!video.paused) {
       video.pause();
       return;
     }


### PR DESCRIPTION
This PR fixes a small issue encountered when autoplaying + auto-repeating a series of successive live photos in the image viewer.

For some reason, not sure why, `this.liveState.playing` remembers the state of the _previous_ image. Thus, when switching between successive live photos, every second photo get incorrectly paused instead of played on load.

Using the builtin `video.paused` attribute seems to fix this.