### PR TITLE
feat: Add separate categories for "live photos" and "panoramas"  and support for 360 PhotoSphere viewer

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,6 +17,8 @@ return [
         ['name' => 'Page#main', 'url' => '/', 'verb' => 'GET'],
         ['name' => 'Page#favorites', 'url' => '/favorites', 'verb' => 'GET'],
         ['name' => 'Page#videos', 'url' => '/videos', 'verb' => 'GET'],
+        ['name' => 'Page#livephotos', 'url' => '/livephotos', 'verb' => 'GET'],
+        ['name' => 'Page#panoramas', 'url' => '/panoramas', 'verb' => 'GET'],
         ['name' => 'Page#archive', 'url' => '/archive', 'verb' => 'GET'],
         ['name' => 'Page#thisday', 'url' => '/thisday', 'verb' => 'GET'],
         ['name' => 'Page#map', 'url' => '/map', 'verb' => 'GET'],

--- a/lib/Controller/DaysController.php
+++ b/lib/Controller/DaysController.php
@@ -115,6 +115,16 @@ class DaysController extends GenericApiController
             $transforms[] = [$this->tq, 'transformVideoFilter'];
         }
 
+        // Filter only live photos
+        if ($this->request->getParam('live')) {
+            $transforms[] = [$this->tq, 'transformLivePhotoFilter'];
+        }
+
+        // Filter only panoramas
+        if ($this->request->getParam('pano')) {
+            $transforms[] = [$this->tq, 'transformPanoFilter'];
+        }
+
         // Filter geological bounds
         if ($bounds = $this->request->getParam('mapbounds')) {
             $transforms[] = [$this->tq, 'transformMapBoundsFilter', $bounds];

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -154,6 +154,26 @@ class PageController extends Controller
      *
      * @NoCSRFRequired
      */
+    public function livephotos(): Response
+    {
+        return $this->main();
+    }
+
+    /**
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     */
+    public function panoramas(): Response
+    {
+        return $this->main();
+    }
+
+    /**
+     * @NoAdminRequired
+     *
+     * @NoCSRFRequired
+     */
     public function archive(): Response
     {
         return $this->main();

--- a/lib/Db/TimelineQueryFilters.php
+++ b/lib/Db/TimelineQueryFilters.php
@@ -9,6 +9,11 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\QueryBuilder\IQueryFunction;
 use OCP\ITags;
 
+// Wikipedia defines a panoramic image as having an aspect ratio of at least 2:1,
+// but some phones approach this with regular photos. Hence, we conservatively set
+// the threshold to 3:1 for true panoramas.
+const PANOROMA_ASPECT_RATIO = 3;
+
 trait TimelineQueryFilters
 {
     public function transformFavoriteFilter(IQueryBuilder &$query, bool $aggregate): void
@@ -35,6 +40,16 @@ trait TimelineQueryFilters
     public function transformVideoFilter(IQueryBuilder &$query, bool $aggregate): void
     {
         $query->andWhere($query->expr()->eq('m.isvideo', $query->expr()->literal(1)));
+    }
+
+    public function transformLivePhotoFilter(IQueryBuilder &$query, bool $aggregate): void
+    {
+        $query->andWhere($query->expr()->neq('m.liveid', $query->expr()->literal('')));
+    }
+
+    public function transformPanoFilter(IQueryBuilder &$query, bool $aggregate): void
+    {
+        $query->andWhere('m.w >= '.PANOROMA_ASPECT_RATIO.' * m.h');
     }
 
     public function transformLimit(IQueryBuilder &$query, bool $aggregate, int $limit): void

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@nextcloud/sharing": "^0.2.3",
         "@nextcloud/upload": "1.6.0",
         "@nextcloud/vue": "^8.19.0",
+        "@photo-sphere-viewer/autorotate-plugin": "^5.11.1",
+        "@photo-sphere-viewer/core": "^5.11.1",
         "filerobot-image-editor": "^4.8.1",
         "fuse.js": "^7.0.0",
         "hammerjs": "^2.0.8",
@@ -2338,6 +2340,24 @@
       "integrity": "sha512-l9Q502TBTaPYGanl1G+hPgd3QX5s4CGnpXriVBR5fEZ/goI6fvDaVmIl3Td8oKFurOxTmbXvBPSsgrd6eu6HYg==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/autorotate-plugin": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/autorotate-plugin/-/autorotate-plugin-5.11.1.tgz",
+      "integrity": "sha512-CZ2GUEU3HEQHqxEDwogtycALBTw3oeY8AFR/WzqR4QkXZBuTPdFU7zDxomqvGCQL8c6BBN0lCMakYybtQwoo/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@photo-sphere-viewer/core": "5.11.1"
+      }
+    },
+    "node_modules/@photo-sphere-viewer/core": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/core/-/core-5.11.1.tgz",
+      "integrity": "sha512-bxWnoQGYjXfmHGee4OSkoYLZmdgqvJWMn7wmpK0V0Vf46Fqu+TJ4Yt8+dY2PgpM89HoKzNr15Dzt6jqOfjkFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "three": "^0.169.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -9770,6 +9790,12 @@
         }
       }
     },
+    "node_modules/three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
+      "license": "MIT"
+    },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -12943,6 +12969,20 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/vue-select/-/vue-select-3.25.1.tgz",
       "integrity": "sha512-jqCi4G+Q0H6+Hm8wSN3vRX2+eXG2jXR2bwBX/sErVEsH5UaxT4Nb7KqgdeIjVfeF7ccIdRqpmIb4Pkf0lao67w==",
       "requires": {}
+    },
+    "@photo-sphere-viewer/autorotate-plugin": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/autorotate-plugin/-/autorotate-plugin-5.11.1.tgz",
+      "integrity": "sha512-CZ2GUEU3HEQHqxEDwogtycALBTw3oeY8AFR/WzqR4QkXZBuTPdFU7zDxomqvGCQL8c6BBN0lCMakYybtQwoo/A==",
+      "requires": {}
+    },
+    "@photo-sphere-viewer/core": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@photo-sphere-viewer/core/-/core-5.11.1.tgz",
+      "integrity": "sha512-bxWnoQGYjXfmHGee4OSkoYLZmdgqvJWMn7wmpK0V0Vf46Fqu+TJ4Yt8+dY2PgpM89HoKzNr15Dzt6jqOfjkFxQ==",
+      "requires": {
+        "three": "^0.169.0"
+      }
     },
     "@playwright/test": {
       "version": "1.47.1",
@@ -18360,6 +18400,11 @@
         "serialize-javascript": "^6.0.1",
         "terser": "^5.26.0"
       }
+    },
+    "three": {
+      "version": "0.169.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.169.0.tgz",
+      "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w=="
     },
     "timers-browserify": {
       "version": "2.0.12",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "@nextcloud/sharing": "^0.2.3",
     "@nextcloud/upload": "1.6.0",
     "@nextcloud/vue": "^8.19.0",
+    "@photo-sphere-viewer/autorotate-plugin": "^5.11.1",
+    "@photo-sphere-viewer/core": "^5.11.1",
     "filerobot-image-editor": "^4.8.1",
     "fuse.js": "^7.0.0",
     "hammerjs": "^2.0.8",

--- a/src/components/Explore.vue
+++ b/src/components/Explore.vue
@@ -54,6 +54,8 @@ import NcButton from '@nextcloud/vue/dist/Components/NcButton.js';
 import FolderIcon from 'vue-material-design-icons/Folder.vue';
 import StarIcon from 'vue-material-design-icons/Star.vue';
 import VideoIcon from 'vue-material-design-icons/PlayCircle.vue';
+import LivePhotoIcon from './icons/LivePhoto.vue';
+import PanoramaVariantIcon from 'vue-material-design-icons/PanoramaVariant.vue';
 import ArchiveIcon from 'vue-material-design-icons/PackageDown.vue';
 import CalendarIcon from 'vue-material-design-icons/Calendar.vue';
 import MapIcon from 'vue-material-design-icons/Map.vue';
@@ -102,6 +104,16 @@ export default defineComponent({
         name: t('memories', 'Videos'),
         icon: VideoIcon,
         link: '/videos',
+      },
+      {
+        name: t('memories', 'Live photos'),
+        icon: LivePhotoIcon,
+        link: '/livephotos',
+      },
+      {
+        name: t('memories', 'Panoramas'),
+        icon: PanoramaVariantIcon,
+        link: '/panoramas',
       },
       {
         name: t('memories', 'Archive'),

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -620,6 +620,16 @@ export default defineComponent({
         set(DaysFilterType.VIDEOS);
       }
 
+      // Live photos
+      if (this.routeIsLivePhotos) {
+        set(DaysFilterType.LIVE);
+      }
+
+      // Panoramas
+      if (this.routeIsPanoramas) {
+        set(DaysFilterType.PANO);
+      }
+
       // Folder
       if (this.routeIsFolders || this.routeIsFolderShare) {
         const path = utils.getFolderRoutePath(this.config.folders_path);

--- a/src/components/viewer/PhotoSphere.vue
+++ b/src/components/viewer/PhotoSphere.vue
@@ -1,0 +1,137 @@
+<template>
+  <div id="viewer" class="viewer__photosphere top-left fill-block">
+    <NcButton
+      id="close-photosphere-viewer"
+      :ariaLabel="t('memories', 'Close')"
+      :title="t('memories', 'Close')"
+      type="tertiary"
+      @click="close"
+    >
+      <CloseThickIcon :size="20" />
+    </NcButton>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue';
+
+import { API } from '@services/API';
+import type { IPhoto } from '@typings';
+import * as utils from '@services/utils';
+
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js';
+import CloseThickIcon from 'vue-material-design-icons/CloseThick.vue';
+
+import { Viewer } from '@photo-sphere-viewer/core';
+import { AutorotatePlugin } from '@photo-sphere-viewer/autorotate-plugin';
+import '@photo-sphere-viewer/core/index.css';
+
+export default defineComponent({
+  props: {
+    photo: {
+      type: Object as PropType<IPhoto>,
+      required: true,
+    },
+  },
+
+  components: {
+    NcButton,
+    CloseThickIcon,
+  },
+
+  emits: {
+    close: () => true,
+  },
+
+  data: () => ({
+    viewer: null as Viewer | null,
+  }),
+
+  async mounted() {
+    // Create the photosphere viewer
+    console.assert(document.getElementById('viewer'), 'PhotoSphere container not found');
+    this.viewer = new Viewer({
+      container: 'viewer',
+      panorama: API.IMAGE_DECODABLE(this.photo.fileid, this.photo.etag),
+      caption: this.exifTitle() + this.exifDate(),
+      description: this.exifDesc(),
+      navbar: ['autorotate', 'zoom', 'move', 'description', 'caption', 'fullscreen'],
+      plugins: [
+        [
+          AutorotatePlugin,
+          {
+            autorotatePitch: '5deg',
+            autostartOnIdle: false,
+            autostartDelay: null,
+          },
+        ],
+      ],
+    });
+
+    // Handle keyboard
+    window.addEventListener('keydown', this.handleKeydown, true);
+  },
+
+  beforeDestroy() {
+    this.close();
+  },
+
+  methods: {
+    exifTitle(): string {
+      const title = this.photo?.imageInfo?.exif?.Title;
+      if (title) return '<b>' + title + '</b> — ';
+      return '';
+    },
+
+    exifDesc(): string | undefined {
+      const desc = this.photo?.imageInfo?.exif?.Description;
+      return desc;
+    },
+
+    exifDate(): string {
+      const date = this.photo?.imageInfo?.datetaken;
+      if (!date) return '';
+      return utils.getLongDateStr(new Date(date * 1000), false, true);
+    },
+
+    close() {
+      this.viewer?.destroy();
+      window.removeEventListener('keydown', this.handleKeydown, true);
+      this.$emit('close');
+    },
+
+    handleKeydown(event: KeyboardEvent) {
+      event.stopImmediatePropagation();
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        this.close();
+      }
+    },
+  },
+});
+</script>
+
+<style lang="scss">
+// Take full screen size
+.viewer__photosphere {
+  z-index: 10100;
+  background-color: black;
+
+  box-sizing: content-box;
+  .psv-container,
+  .psv-container * {
+    box-sizing: content-box !important;
+  }
+
+  // Overlay top-right close button
+  #close-photosphere-viewer {
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 9999;
+    //background-color: transparent;
+    margin-right: 10px;
+  }
+}
+</style>

--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -8,6 +8,7 @@
     @fullscreenchange="fullscreenChange"
   >
     <ImageEditor v-if="editorOpen && currentPhoto" :photo="currentPhoto" @close="editorOpen = false" />
+    <PhotoSphere v-if="sphereOpen && currentPhoto" :photo="currentPhoto" @close="sphereOpen = false" />
 
     <!-- Loading indicator -->
     <XLoadingIcon class="loading-icon centered" v-if="loading" />
@@ -15,7 +16,7 @@
     <div
       ref="inner"
       class="inner"
-      v-show="!editorOpen"
+      v-show="!editorOpen && !sphereOpen"
       @pointermove.passive="setUiVisible"
       @pointerdown.passive="setUiVisible"
     >
@@ -66,6 +67,7 @@ import * as utils from '@services/utils';
 import * as nativex from '@native';
 
 import ImageEditor from './ImageEditor.vue';
+import PhotoSphere from './PhotoSphere.vue';
 import PhotoSwipe, { type PhotoSwipeOptions } from 'photoswipe';
 import 'photoswipe/style.css';
 import PsImage from './PsImage';
@@ -84,6 +86,7 @@ import DownloadIcon from 'vue-material-design-icons/Download.vue';
 import InfoIcon from 'vue-material-design-icons/InformationOutline.vue';
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue';
 import TuneIcon from 'vue-material-design-icons/Tune.vue';
+import PanoramaSphereOutlineIcon from 'vue-material-design-icons/PanoramaSphereOutline.vue';
 import SlideshowIcon from 'vue-material-design-icons/PlayBox.vue';
 import EditFileIcon from 'vue-material-design-icons/FileEdit.vue';
 import AlbumRemoveIcon from 'vue-material-design-icons/BookRemove.vue';
@@ -116,6 +119,7 @@ export default defineComponent({
     NcActions,
     NcActionButton,
     ImageEditor,
+    PhotoSphere,
   },
 
   mixins: [UserConfig],
@@ -125,6 +129,7 @@ export default defineComponent({
     isOpen: false,
     originalTitle: null as string | null,
     editorOpen: false,
+    sphereOpen: false,
     editorSrc: '',
 
     show: false,
@@ -278,6 +283,13 @@ export default defineComponent({
           if: true,
         },
         {
+          id: 'sphere',
+          name: this.t('memories', 'Open in PhotoSphere'),
+          icon: PanoramaSphereOutlineIcon,
+          callback: this.openSphere,
+          if: !this.isVideo,
+        },
+        {
           id: 'edit',
           name: this.t('memories', 'Edit'),
           icon: TuneIcon,
@@ -382,7 +394,7 @@ export default defineComponent({
 
     /** Allow closing the viewer */
     allowClose(): boolean {
-      return !this.editorOpen && !dav.isSingleItem() && !this.slideshowTimer;
+      return !this.editorOpen && !this.sphereOpen && !dav.isSingleItem() && !this.slideshowTimer;
     },
 
     /** Get date taken string */
@@ -1014,6 +1026,10 @@ export default defineComponent({
 
       // Open editor
       this.editorOpen = true;
+    },
+
+    async openSphere() {
+      this.sphereOpen = true;
     },
 
     /** Share the current photo externally */

--- a/src/router.ts
+++ b/src/router.ts
@@ -18,6 +18,8 @@ export type RouteId =
   | 'Folders'
   | 'Favorites'
   | 'Videos'
+  | 'LivePhotos'
+  | 'Panoramas'
   | 'Albums'
   | 'Archive'
   | 'ThisDay'
@@ -58,6 +60,20 @@ export const routes: { [key in RouteId]: RouteConfig } = {
     component: Timeline,
     name: 'videos',
     props: (route: Route) => ({ rootTitle: t('memories', 'Videos') }),
+  },
+
+  Panoramas: {
+    path: '/panoramas',
+    component: Timeline,
+    name: 'panoramas',
+    props: (route: Route) => ({ rootTitle: t('memories', 'Panoramas') }),
+  },
+
+  LivePhotos: {
+    path: '/livephotos',
+    component: Timeline,
+    name: 'livephotos',
+    props: (route: Route) => ({ rootTitle: t('memories', 'Live photos') }),
   },
 
   Albums: {

--- a/src/services/API.ts
+++ b/src/services/API.ts
@@ -20,6 +20,8 @@ function tok(url: string) {
 export const enum DaysFilterType {
   FAVORITES = 'fav',
   VIDEOS = 'vid',
+  LIVE = 'live',
+  PANO = 'pano',
   FOLDER = 'folder',
   ARCHIVE = 'archive',
   ALBUM = 'albums',

--- a/src/services/strings.ts
+++ b/src/services/strings.ts
@@ -41,6 +41,10 @@ export function viewName(routeName: string): string {
       return t('memories', 'People');
     case _m.routes.Videos.name:
       return t('memories', 'Videos');
+    case _m.routes.LivePhotos.name:
+      return t('memories', 'Live photos');
+    case _m.routes.Panoramas.name:
+      return t('memories', 'Panoramas');
     case _m.routes.Albums.name:
       return t('memories', 'Albums');
     case _m.routes.Archive.name:


### PR DESCRIPTION
Add the following features:

* separate API and category in the "explore" menu for live photos and panoramas cf #676
    - includes a heuristic to identify "panoramas" based on >= 3:1 aspect ratio
* full integration with [Photo Sphere Viewer JavaScript library](https://photo-sphere-viewer.js.org/) cf #1036 and #931  
    - this can be opened from a new "open in PhotoSphere" button in the image viewer
    - Tested this on mobile and desktop on my end.

Possible further improvements:
* only show the  "open in PhotoSphere" button for pictures that we labeled as "panoramas"?
* parse the XMP metadata to discover actual photospheres, even if they are < 3:1? This is what the `files/photosphere` NC app [seems to do](https://github.com/nextcloud/files_photospheres/blob/master/lib/Service/Helper/XmpDataReader.php). In principle, this could be done server side and cached in the `oc_memories` table, but not all panorama pictures include XMP data afaik.

![image](https://github.com/user-attachments/assets/e982f525-4258-4d50-a505-e4d73b93f135)
![image](https://github.com/user-attachments/assets/04f4fc45-ca5b-4c9b-87ab-2656f7bb8ad7)

