### PR TITLE
feat: show photos of shared album in timeline

### DIFF
--- a/lib/Controller/OtherController.php
+++ b/lib/Controller/OtherController.php
@@ -100,6 +100,7 @@ class OtherController extends GenericApiController
 
                 // general settings
                 'timeline_path' => $getAppConfig('timelinePath', SystemConfig::get('memories.timeline.default_path')),
+                'timeline_include_shared_albums' => $getAppConfig('timelineHasSharedAlbums', SystemConfig::get('memories.timeline.default_include_shared_albums')),
                 'enable_top_memories' => 'true' === $getAppConfig('enableTopMemories', 'true'),
                 'stack_raw_files' => 'true' === $getAppConfig('stackRawFiles', 'true'),
 

--- a/lib/Db/FsManager.php
+++ b/lib/Db/FsManager.php
@@ -120,6 +120,7 @@ class FsManager
             $paths = [$path];
         } else {
             $paths = Util::getTimelinePaths($uid);
+            $root->addSharedAlbums(Util::getTimelineIncludeSharedAlbums($uid));
         }
 
         // Combined etag, for cache invalidation.

--- a/lib/Db/TimelineRoot.php
+++ b/lib/Db/TimelineRoot.php
@@ -14,6 +14,8 @@ class TimelineRoot
     /** @var array<int, string> */
     protected array $folderPaths = [];
 
+    protected bool $sharedAlbums = false;
+
     /**
      * Add a folder to the root.
      *
@@ -33,6 +35,11 @@ class TimelineRoot
 
         // Add top level folder
         $this->setFolder($info->getId() ?? 0, $info, $path);
+    }
+
+    public function addSharedAlbums(bool $include = true): void
+    {
+        $this->sharedAlbums = $include;
     }
 
     /**
@@ -111,6 +118,11 @@ class TimelineRoot
     public function isEmpty(): bool
     {
         return empty($this->folderPaths);
+    }
+
+    public function includeSharedAlbums(): bool
+    {
+        return $this->sharedAlbums;
     }
 
     private function setFolder(int $id, ?FileInfo $fileInfo, ?string $path): void

--- a/lib/Settings/SystemConfig.php
+++ b/lib/Settings/SystemConfig.php
@@ -44,6 +44,9 @@ class SystemConfig
         // If set to '_empty_', the user is prompted to select a path
         'memories.timeline.default_path' => '_empty_',
 
+        // Whether to include files accessible via shared albums in the timeline by default
+        'memories.timeline.default_include_shared_albums' => true,
+
         // Default viewer high resolution image loading condition
         // Valid values: 'always' | 'zoom' | 'never'
         'memories.viewer.high_res_cond_default' => 'zoom',

--- a/lib/Util.php
+++ b/lib/Util.php
@@ -321,6 +321,18 @@ class Util
         );
     }
 
+    public static function getTimelineIncludeSharedAlbums(string $uid): bool
+    {
+        return 'true' === \OC::$server->get(IConfig::class)
+            ->getUserValue(
+                $uid,
+                Application::APPNAME,
+                'timelineIncludeSharedAlbums',
+                SystemConfig::get('memories.timeline.default_include_shared_albums') ? 'true' : 'false',
+            )
+        ;
+    }
+
     /**
      * Run a callback in a transaction.
      * It returns the same type as the return type of the closure.

--- a/src/components/SelectionManager.vue
+++ b/src/components/SelectionManager.vue
@@ -200,7 +200,7 @@ export default defineComponent({
         name: t('memories', 'Delete'),
         icon: DeleteIcon,
         callback: this.deleteSelection.bind(this),
-        if: () => !this.routeIsAlbums,
+        if: () => !this.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'Remove from album'),
@@ -212,7 +212,7 @@ export default defineComponent({
         name: t('memories', 'Share'),
         icon: ShareIcon,
         callback: this.shareSelection.bind(this),
-        if: () => !this.routeIsAlbums,
+        if: () => !this.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'Download'),
@@ -230,7 +230,7 @@ export default defineComponent({
         name: t('memories', 'Archive'),
         icon: ArchiveIcon,
         callback: this.archiveSelection.bind(this),
-        if: () => !this.routeIsArchiveFolder() && !this.routeIsAlbums,
+        if: () => !this.routeIsArchiveFolder() && !this.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'Unarchive'),
@@ -242,17 +242,19 @@ export default defineComponent({
         name: t('memories', 'Edit metadata'),
         icon: EditFileIcon,
         callback: this.editMetadataSelection.bind(this),
+        if: () => !this.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'Rotate / Flip'),
         icon: RotateLeftIcon,
         callback: () => this.editMetadataSelection(this.selection, [5]),
+        if: () => !this.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'View in folder'),
         icon: OpenInNewIcon,
         callback: this.viewInFolder.bind(this),
-        if: () => this.selection.size === 1 && !this.routeIsAlbums,
+        if: () => this.selection.size === 1 && !this.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'Set as cover image'),
@@ -264,13 +266,13 @@ export default defineComponent({
         name: t('memories', 'Move to folder'),
         icon: FolderMoveIcon,
         callback: this.moveToFolder.bind(this),
-        if: () => !this.routeIsAlbums && !this.routeIsArchiveFolder(),
+        if: () => !this.routeIsAlbums && !this.routeIsArchiveFolder() && this.selectionInTimelinePath(),
       },
       {
         name: t('memories', 'Add to album'),
         icon: AlbumsIcon,
         callback: this.addToAlbum.bind(this),
-        if: (self: any) => self.config.albums_enabled && !self.routeIsAlbums,
+        if: (self: any) => self.config.albums_enabled && !self.routeIsAlbums && this.selectionInTimelinePath(),
       },
       {
         id: 'face-move',
@@ -333,6 +335,10 @@ export default defineComponent({
       }
 
       return false;
+    },
+
+    selectionInTimelinePath() {
+      return !Array.from(this.selection.values()).some((photo) => photo.src);
     },
 
     /** Trigger to update props from selection set */

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -17,6 +17,14 @@
           readonly
         />
 
+        <NcCheckboxRadioSwitch
+          :checked.sync="config.timeline_include_shared_albums"
+          @update:checked="updateTimelineIncludeSharedAlbums"
+          type="switch"
+        >
+          {{ t('memories', 'Include shared albums in timeline') }}
+        </NcCheckboxRadioSwitch>
+
         <NcCheckboxRadioSwitch :checked.sync="config.square_thumbs" @update:checked="updateSquareThumbs" type="switch">
           {{ t('memories', 'Square grid mode') }}
         </NcCheckboxRadioSwitch>
@@ -310,6 +318,10 @@ export default defineComponent({
     },
 
     // General settings
+    async updateTimelineIncludeSharedAlbums() {
+      await this.updateSetting('timeline_include_shared_albums', 'timelineIncludeSharedAlbums');
+    },
+
     async updateSquareThumbs() {
       await this.updateSetting('square_thumbs');
     },

--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -310,7 +310,7 @@ export default defineComponent({
           name: this.t('memories', 'View in folder'),
           icon: OpenInNewIcon,
           callback: this.viewInFolder,
-          if: !this.routeIsPublic && !this.routeIsAlbums && !this.isLocal,
+          if: !this.routeIsPublic && !this.routeIsAlbums && !this.isLocal && !this.currentPhoto?.src,
         },
         {
           id: 'slideshow',

--- a/src/services/static-config.ts
+++ b/src/services/static-config.ts
@@ -132,6 +132,7 @@ class StaticConfig {
 
       // general settings
       timeline_path: '_unknown_',
+      timeline_include_shared_albums: true,
       enable_top_memories: true,
       stack_raw_files: true,
       dedup_identical: false,

--- a/src/typings/config.d.ts
+++ b/src/typings/config.d.ts
@@ -19,6 +19,7 @@ declare module '@typings' {
 
     // general settings
     timeline_path: string;
+    timeline_include_shared_albums: boolean;
     enable_top_memories: boolean;
     stack_raw_files: boolean;
     dedup_identical: boolean;

--- a/src/typings/data.d.ts
+++ b/src/typings/data.d.ts
@@ -99,6 +99,8 @@ declare module '@typings' {
 
     /** Stacked RAW photos */
     stackraw?: IPhoto[];
+
+    src?: string;
   };
 
   export interface IImageInfo {


### PR DESCRIPTION
Fixes #503, also possibly closes #724 and closes #947

This modifies the main DB query and adds a UI switch to optionally show photos of shared albums in the timeline.

Tested on MySQL and PostgreSQL.

Note: as the UI needs to be properly aware this is a read-only shared album photo or a photo from a (read-write) timeline directory, I needed to convert the subquery SELECT to a JOIN statement. Not sure if/how this impacts performance and if there is an easy way to measure performance impact, eg using a benchmark query (?)