### PR TITLE
Ensure consistent .sh line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 l10n/** linguist-vendored
+*.sh text eol=lf


### PR DESCRIPTION
This fixes the line endings for (at least) `.devcontainer/postCreate.sh` when git cloning the repository on Windows, and then opening the devcontainer (Linux environment).

Throws `line 25: $'\r': command not found` otherwise.