### PR TITLE
Chore: Update CI actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           key: ${{ github.ref }}
           path: .cache

--- a/.github/workflows/go-vod.yml
+++ b/.github/workflows/go-vod.yml
@@ -61,7 +61,7 @@ jobs:
         run: echo "label=${GITHUB_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build container image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
 


### PR DESCRIPTION
They bumped some major Action versions due to Node.js upgrades and similar, but none of the potential breaking changes seem to matter to Memories.