### PR TITLE
Use system default for timezone

### DIFF
--- a/lib/Db/TimelineWrite.php
+++ b/lib/Db/TimelineWrite.php
@@ -9,6 +9,7 @@ use OCA\Memories\Service\Index;
 use OCA\Memories\Util;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
 use Psr\Log\LoggerInterface;
@@ -28,6 +29,7 @@ class TimelineWrite
         protected LivePhoto $livePhoto,
         protected ILockingProvider $lockingProvider,
         protected LoggerInterface $logger,
+        protected IConfig $config,
     ) {}
 
     /**
@@ -121,7 +123,7 @@ class TimelineWrite
         [$lat, $lon, $mapCluster] = $this->processExifLocation($fileId, $exif, $prevRow);
 
         // Get date parameters (after setting timezone offset)
-        $dateTaken = Exif::getDateTaken($file, $exif);
+        $dateTaken = Exif::getDateTaken($file, $exif, $this->config->getSystemValue('default_timezone', 'UTC'));
 
         // Store the acutal epoch with the EXIF data
         $epoch = $exif['DateTimeEpoch'] = $dateTaken->getTimestamp();

--- a/lib/Db/TimelineWrite.php
+++ b/lib/Db/TimelineWrite.php
@@ -9,7 +9,6 @@ use OCA\Memories\Service\Index;
 use OCA\Memories\Util;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\File;
-use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Lock\ILockingProvider;
 use Psr\Log\LoggerInterface;
@@ -29,7 +28,6 @@ class TimelineWrite
         protected LivePhoto $livePhoto,
         protected ILockingProvider $lockingProvider,
         protected LoggerInterface $logger,
-        protected IConfig $config,
     ) {}
 
     /**
@@ -123,7 +121,7 @@ class TimelineWrite
         [$lat, $lon, $mapCluster] = $this->processExifLocation($fileId, $exif, $prevRow);
 
         // Get date parameters (after setting timezone offset)
-        $dateTaken = Exif::getDateTaken($file, $exif, $this->config->getSystemValue('default_timezone', 'UTC'));
+        $dateTaken = Exif::getDateTaken($file, $exif);
 
         // Store the acutal epoch with the EXIF data
         $epoch = $exif['DateTimeEpoch'] = $dateTaken->getTimestamp();

--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -6,6 +6,7 @@ namespace OCA\Memories;
 
 use OCA\Memories\AppInfo\Application;
 use OCA\Memories\Service\BinExt;
+use OCA\Memories\Settings\SystemConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\File;
@@ -236,7 +237,7 @@ class Exif
      *
      * @param array<string, mixed> $exif
      */
-    public static function getDateTaken(File $file, array $exif, string $timezone): \DateTime
+    public static function getDateTaken(File $file, array $exif): \DateTime
     {
         try {
             return self::parseExifDate($exif);
@@ -248,7 +249,7 @@ class Exif
         $dt = new \DateTime('@'.$file->getMtime());
 
         // Set timezone to system timezone
-        $tz = $timezone ?: getenv('TZ') ?: date_default_timezone_get();
+        $tz = SystemConfig::get('default_timezone') ?: getenv('TZ') ?: date_default_timezone_get();
 
         try {
             $dt->setTimezone(new \DateTimeZone($tz));

--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -236,7 +236,7 @@ class Exif
      *
      * @param array<string, mixed> $exif
      */
-    public static function getDateTaken(File $file, array $exif): \DateTime
+    public static function getDateTaken(File $file, array $exif, string $timezone): \DateTime
     {
         try {
             return self::parseExifDate($exif);
@@ -248,7 +248,7 @@ class Exif
         $dt = new \DateTime('@'.$file->getMtime());
 
         // Set timezone to system timezone
-        $tz = getenv('TZ') ?: date_default_timezone_get();
+        $tz = $timezone ?: getenv('TZ') ?: date_default_timezone_get();
 
         try {
             $dt->setTimezone(new \DateTimeZone($tz));

--- a/lib/Settings/SystemConfig.php
+++ b/lib/Settings/SystemConfig.php
@@ -111,6 +111,7 @@ class SystemConfig
         'preview_max_memory' => 128,
         'preview_max_filesize_image' => 50,
         'preview_ffmpeg_path' => '',
+        'default_timezone' => '',
 
         // Placeholders only; these are not touched by the app
         'instanceid' => 'default',


### PR DESCRIPTION
The TZ environment variable is not set on many machines and date_default_timezone_get only works if the timezone has been set elsewhere. Instead, this approach relies on the Nextcloud server configuration for the timezone.

Closes #1240

See: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#default-timezone