### PR TITLE
chore(tests): Also test with PHP 8.3

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.2', '8.3']
         server-versions: ['stable29', 'stable30', 'stable31']
 
     steps:


### PR DESCRIPTION
Why?

Test with all current NC versions + all PHP versions that are supported by all NC versions

https://github.com/nextcloud/server/wiki/Releases-and-PHP-versions


Successor to  #1435