### PR TITLE
Add the capability to multi-select from within the Viewer using UI or keyboard shortcuts.

### DIFF
--- a/src/components/SelectionManager.vue
+++ b/src/components/SelectionManager.vue
@@ -191,9 +191,14 @@ export default defineComponent({
     touchScrollDelta: 0,
     touchMoveSelFrame: 0,
     multiSelectDelta: null as 1 | -1 | null,
+    shouldPersistSelections: false,
   }),
 
   mounted() {
+    _m.selectionManager = {
+      selectPhoto: this.selectPhoto.bind(this) as typeof this.selectPhoto,
+    };
+
     // Make default actions
     this.defaultActions = [
       {
@@ -643,10 +648,12 @@ export default defineComponent({
         photo.flag |= this.c.FLAG_SELECTED;
         this.selection.addBy(photo);
         this.selectionChanged();
+        console.log('added photo', this.selection);
       } else {
         photo.flag &= ~this.c.FLAG_SELECTED;
         this.selection.deleteBy(photo);
         this.selectionChanged();
+        console.log('removed photo', this.selection);
       }
 
       if (!noUpdate) {

--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -89,6 +89,8 @@ import EditFileIcon from 'vue-material-design-icons/FileEdit.vue';
 import AlbumRemoveIcon from 'vue-material-design-icons/BookRemove.vue';
 import AlbumIcon from 'vue-material-design-icons/ImageAlbum.vue';
 import RotateLeftIcon from 'vue-material-design-icons/RotateLeft.vue';
+import CheckCircleIcon from 'vue-material-design-icons/CheckCircle.vue';
+import CheckboxBlankCircleOutline from 'vue-material-design-icons/CheckboxBlankCircleOutline.vue';
 
 type IViewerAction = {
   /** Identifier (optional) */
@@ -231,6 +233,13 @@ export default defineComponent({
     /** Get all actions to show */
     actions(): IViewerAction[] {
       return [
+        {
+          id: 'select',
+          name: this.t('memories', 'Select'),
+          icon: (this.currentPhoto?.flag ?? 0) & this.c.FLAG_SELECTED ? CheckCircleIcon : CheckboxBlankCircleOutline,
+          callback: this.toggleSelectCurrent,
+          if: true,
+        },
         {
           id: 'share',
           name: this.t('memories', 'Share'),
@@ -698,6 +707,22 @@ export default defineComponent({
 
       // Remove fragment if closed
       if (!this.isOpen) {
+        const fragments = utils.fragment.list;
+        const hasSelection = fragments.some((f) => f.type === utils.fragment.types.selection);
+
+        // We selected some photos while using the viewer.
+        if (hasSelection) {
+          // Keep the selection by replacing the route.
+          const newFragments = fragments.filter((f) => f.type !== utils.fragment.types.viewer);
+          const hash = utils.fragment.encode(newFragments);
+
+          return _m.router.replace({
+            path: _m.route.path,
+            query: _m.route.query,
+            hash: hash,
+          });
+        }
+
         return utils.fragment.pop(utils.fragment.types.viewer);
       }
     },
@@ -1034,12 +1059,23 @@ export default defineComponent({
     keydown(e: KeyboardEvent) {
       if (e.defaultPrevented) return;
 
+      if (e.key == ' ') {
+        this.toggleSelectCurrent();
+      }
+
       if (e.key === 'Delete') {
         this.deleteCurrent();
       }
 
       if (e.key === 'Tab') {
         this.photoswipe?.element?.classList.add('pswp--ui-visible');
+      }
+    },
+
+    /** Select the current photo */
+    toggleSelectCurrent() {
+      if (this.currentPhoto) {
+        _m.selectionManager.selectPhoto(this.currentPhoto);
       }
     },
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -50,6 +50,10 @@ declare global {
       search: () => void;
     };
 
+    selectionManager: {
+      selectPhoto: (photo: IPhoto, val?: boolean, noUpdate?: boolean) => void;
+    };
+
     sidebar: {
       open: (photo: IPhoto | number, filename?: string, forceNative?: boolean) => void;
       close: () => void;

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ globalThis._m = {
   routes: routes,
 
   modals: {} as any,
+  selectionManager: {} as any,
   sidebar: {} as any,
   viewer: {} as any,
   video: {} as any,

--- a/src/services/utils/fragment.ts
+++ b/src/services/utils/fragment.ts
@@ -193,6 +193,8 @@ export const fragment = {
   get viewer() {
     return this.get(FragmentType.viewer);
   },
+
+  encode: encodeFragment,
 };
 
 onDOMLoaded(() => {


### PR DESCRIPTION
A feature I find essential in photo management software is the ability to quickly flick through a large set of photos and 'audit' them before I add them to my library permanently.

The common workflow in tools like Lightroom is to use keyboard shortcuts while fullscreened to multi-select a group that you can then do whatever you like with (e.g. delete).

I found this cumbersome in Memories, so added the functionality.

<img width="226" height="94" alt="image" src="https://github.com/user-attachments/assets/8aa0e686-be87-4b39-a1a8-595f6a603fc2" />
<img width="355" height="123" alt="image" src="https://github.com/user-attachments/assets/f582e83b-669e-4644-b428-d3a3c4d4ac1d" />

- There is an empty circle / checkmark in the action bar of the `Viewer` that indicates current selection status.
- You can press `' '` (space bar) to select/de-select current image.
- When you return to the timeline, your images will be selected.

It's my first time contributing to this repo, so please let me know:

1. If the approach makes sense (especially for the `selected` fragment handling).
2. If I should add any test cases (I saw no existing tests for the viewer).