### PR TITLE
Add upload button in public shares

### DIFF
--- a/src/components/top-matter/FolderTopMatter.vue
+++ b/src/components/top-matter/FolderTopMatter.vue
@@ -32,6 +32,17 @@
           <template #icon> <UploadIcon :size="20" /> </template>
         </NcActionButton>
 
+        <!-- NEW PUBLIC UPLOAD BUTTON -->
+        <NcActionButton
+          v-if="routeIsPublic && allowUpload"
+          :aria-label="t('memories', 'Upload files')"
+          :disabled="isUploading"
+          @click="triggerFileUpload"
+        >
+          {{ isUploading ? t('memories', 'Uploading...') : t('memories', 'Upload files') }}
+          <template #icon> <UploadIcon :size="20" /> </template>
+        </NcActionButton>
+
         <NcActionButton @click="toggleRecursive" close-after-click>
           {{ recursive ? t('memories', 'Folder view') : t('memories', 'Timeline view') }}
           <template #icon>
@@ -41,11 +52,22 @@
         </NcActionButton>
       </NcActions>
     </div>
+
+    <!-- Hidden file input that we trigger programmatically -->
+    <input ref="fileInput" type="file" style="display: none" multiple @change="handleFileSelection" />
+
+    <!-- NEW UPLOAD PROGRESS DISPLAY -->
+    <div v-if="isUploading" class="upload-progress">
+      <progress :value="uploadProgress" max="100"></progress>
+      <span>{{ uploadStatus }}</span>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { generateUrl } from '@nextcloud/router';
+import { t } from '@nextcloud/l10n';
 
 import UserConfig from '@mixins/UserConfig';
 
@@ -80,6 +102,16 @@ export default defineComponent({
 
   mixins: [UserConfig],
 
+  data() {
+    return {
+      isUploading: false,
+      uploadProgress: 0,
+      uploadStatus: '',
+      uploadCount: 0,
+      uploadFailures: 0,
+    };
+  },
+
   computed: {
     list(): {
       text: string;
@@ -110,6 +142,10 @@ export default defineComponent({
     isNative(): boolean {
       return nativex.has();
     },
+    
+    allowUpload(): boolean {
+      return this.initstate.allow_upload === true;
+    },
   },
 
   methods: {
@@ -137,6 +173,90 @@ export default defineComponent({
         hash: undefined,
       };
     },
+
+    // --- NEW UPLOAD LOGIC ---
+    triggerFileUpload() {
+      (this.$refs.fileInput as HTMLInputElement).click();
+    },
+
+    handleFileSelection(event: Event) {
+      const target = event.target as HTMLInputElement;
+      const files = target.files;
+      if (!files || files.length === 0) {
+        return;
+      }
+
+      this.uploadCount = files.length;
+      this.uploadFailures = 0;
+      this.isUploading = true;
+      this.uploadProgress = 0;
+
+      for (const file of files) {
+        this.uploadFile(file);
+      }
+
+      target.value = '';
+    },
+
+    uploadFile(file: File) {
+      const token = this.$route.params.token as string;
+      const url = generateUrl(`/apps/memories/s/${token}/upload`);
+
+      const formData = new FormData();
+      formData.append('file', file);
+
+      const xhr = new XMLHttpRequest();
+      xhr.open('POST', url, true);
+
+      this.uploadStatus = t('memories', 'Uploading {file}...', { file: file.name });
+
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) {
+          this.uploadProgress = (e.loaded / e.total) * 100;
+        }
+      };
+
+      const onFinish = (success: boolean) => {
+        if (!success) {
+            this.uploadFailures++;
+        }
+        this.uploadCount--;
+
+        if (this.uploadCount <= 0) {
+            this.isUploading = false;
+            this.uploadProgress = 0;
+            
+            if (this.uploadFailures > 0) {
+                this.uploadStatus = t('memories', '{count} files failed to upload.', { count: this.uploadFailures });
+            } else {
+                this.uploadStatus = t('memories', 'All files uploaded successfully.');
+                window.location.reload();
+            }
+        }
+      };
+
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          onFinish(true);
+        } else {
+          try {
+            const response = JSON.parse(xhr.responseText);
+            this.uploadStatus = t('memories', 'Upload of {file} failed: {error}', { file: file.name, error: response.error || xhr.statusText });
+          } catch (e) {
+            this.uploadStatus = t('memories', 'Upload of {file} failed: {error}', { file: file.name, error: xhr.statusText });
+          }
+          onFinish(false);
+        }
+      };
+
+      xhr.onerror = () => {
+        this.uploadStatus = t('memories', 'An error occurred during the upload of {file}', { file: file.name });
+        onFinish(false);
+      };
+
+      xhr.send(formData);
+    },
+    // --- END OF NEW UPLOAD LOGIC ---
   },
 });
 </script>
@@ -151,4 +271,18 @@ export default defineComponent({
     }
   }
 }
+
+.upload-progress {
+  grid-column: 1 / -1;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.upload-progress progress {
+  flex-grow: 1;
+}
 </style>
+


### PR DESCRIPTION
**Feature: Anonymous uploads for public folder shares**

This pull request adds the ability for anonymous users to upload files to public folder shares.

The upload button will only appear on a public share link if it has been created with "Can edit" permissions, ensuring that folder owners retain full control. When a user uploads files, a progress bar is displayed. After the upload is successfully completed, the page reloads to show the newly added files.

Below are some screenshots of the process for uploading to a public share:

1. Visible upload button in a public share. No user is logged in. <img width="2494" height="737" alt="Screenshot from 2025-08-31 19-43-09" src="https://github.com/user-attachments/assets/98fc0829-b000-45ac-8f1e-560a6b0066f2" />
2. Menu when the upload button is pressed. <img width="1777" height="739" alt="Screenshot from 2025-08-31 19-30-33" src="https://github.com/user-attachments/assets/ae94fad9-de47-4c3c-9c3b-a844a4362e3d" />
3. Progress bar for the upload. <img width="1777" height="739" alt="Screenshot from 2025-08-31 19-36-55" src="https://github.com/user-attachments/assets/cd38bc1b-d1ef-4feb-9cb9-04d235a72d03" />
4. New uploaded image is available in the folder. <img width="1777" height="739" alt="Screenshot from 2025-08-31 19-30-51" src="https://github.com/user-attachments/assets/b29be410-3c3d-44fa-9637-b3c0779f1d0b" />





