### PR TITLE
remove .toLowerCase() from  welcome.html

### DIFF
--- a/android/app/src/main/assets/welcome.html
+++ b/android/app/src/main/assets/welcome.html
@@ -58,7 +58,7 @@
       }
 
       function getUrl() {
-          const url = urlBox.value.toLowerCase();
+          const url = urlBox.value;
           if (!url.startsWith("http://") && !url.startsWith("https://")) {
               return "https://" + url;
           }


### PR DESCRIPTION
Calling to .toLowerCase() on the URL, breaks logging into a nextcloud instance that lives behind a prefix containing upper case characters.