### PR TITLE
Update VAAPI hwaccel command for stream transcoding

### DIFF
--- a/go-vod/transcoder/stream.go
+++ b/go-vod/transcoder/stream.go
@@ -370,7 +370,7 @@ func (s *Stream) transcodeArgs(startAt float64, isHls bool) []string {
 	// Check whether hwaccel should be used
 	if s.c.VAAPI {
 		CV = ENCODER_VAAPI
-		extra := "-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi"
+		extra := "-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -init_hw_device vaapi=/dev/dri/renderD128 -hwaccel_output_format vaapi"
 		args = append(args, strings.Split(extra, " ")...)
 	} else if s.c.NVENC {
 		CV = ENCODER_NVENC


### PR DESCRIPTION
Corrected ffmpeg argument for vaapi hw acceleration.

Closes https://github.com/pulsejet/memories/issues/1208

Here are the logs from before and after the patch.

[go-vod-log-ok.txt](https://github.com/user-attachments/files/23442216/go-vod-log-ok.txt)
[go-vod-log-nok.txt](https://github.com/user-attachments/files/23442217/go-vod-log-nok.txt)