### PR TITLE
feat: add video loop option

### DIFF
--- a/lib/Controller/OtherController.php
+++ b/lib/Controller/OtherController.php
@@ -108,6 +108,7 @@ class OtherController extends GenericApiController
                 'high_res_cond_default' => SystemConfig::get('memories.viewer.high_res_cond_default'),
                 'livephoto_autoplay' => 'true' === $getAppConfig('livephotoAutoplay', 'false'),
                 'livephoto_loop' => 'true' === $getAppConfig('livephotoLoop', 'false'),
+                'video_loop' => 'true' === $getAppConfig('videoLoop', 'false'),
                 'sidebar_filepath' => 'true' === $getAppConfig('sidebarFilepath', false),
 
                 // folder settings

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -71,6 +71,10 @@
           {{ t('memories', 'Loop Live Photos') }}
         </NcCheckboxRadioSwitch>
 
+        <NcCheckboxRadioSwitch :checked.sync="config.video_loop" @update:checked="updateVideoLoop" type="switch">
+          {{ t('memories', 'Loop Videos') }}
+        </NcCheckboxRadioSwitch>
+
         <NcCheckboxRadioSwitch
           :checked.sync="config.sidebar_filepath"
           @update:checked="updateSidebarFilepath"
@@ -358,6 +362,10 @@ export default defineComponent({
 
     async updateLivephotoLoop() {
       await this.updateSetting('livephoto_loop', 'livephotoLoop');
+    },
+
+    async updateVideoLoop() {
+      await this.updateSetting('video_loop', 'videoLoop');
     },
 
     async updateSidebarFilepath() {

--- a/src/components/viewer/PsVideo.ts
+++ b/src/components/viewer/PsVideo.ts
@@ -351,6 +351,9 @@ class VideoContentSetup {
         // and this container is computed during construction
         // https://github.com/sampotts/plyr/blob/20bf5a883306e9303b325e72c9102d76cc733c47/src/js/fullscreen.js#L30
       },
+      loop: {
+        active: staticConfig.getSync('video_loop'),
+      },
     };
 
     // Add quality options

--- a/src/services/static-config.ts
+++ b/src/services/static-config.ts
@@ -141,6 +141,7 @@ class StaticConfig {
       high_res_cond_default: 'zoom',
       livephoto_autoplay: true,
       livephoto_loop: false,
+      video_loop: false,
       sidebar_filepath: false,
       metadata_in_slideshow: false,
 

--- a/src/typings/config.d.ts
+++ b/src/typings/config.d.ts
@@ -28,6 +28,7 @@ declare module '@typings' {
     high_res_cond_default: HighResCond;
     livephoto_autoplay: boolean;
     livephoto_loop: boolean;
+    video_loop: boolean;
     sidebar_filepath: boolean;
     metadata_in_slideshow: boolean;
 


### PR DESCRIPTION
Add an new option for enable video looping and pass it to Plyr.
On default the option is disabled, so nothing should change for existing users.

Was implemented similar like the existing "Loop Live Photos" option.

Closes #251