### PR TITLE
Fix #1591 ffmpeg 8 error: `init_hw_device` for `hwupload` with VAAPI

### DIFF
--- a/go-vod/transcoder/stream.go
+++ b/go-vod/transcoder/stream.go
@@ -370,7 +370,7 @@ func (s *Stream) transcodeArgs(startAt float64, isHls bool) []string {
 	// Check whether hwaccel should be used
 	if s.c.VAAPI {
 		CV = ENCODER_VAAPI
-		extra := "-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi"
+		extra := "-hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -hwaccel_output_format vaapi -init_hw_device vaapi=memories:/dev/dri/renderD128 -filter_hw_device memories"
 		args = append(args, strings.Split(extra, " ")...)
 	} else if s.c.NVENC {
 		CV = ENCODER_NVENC


### PR DESCRIPTION
This fixes https://github.com/pulsejet/memories/issues/1591 and https://github.com/NixOS/nixpkgs/issues/473008 by extension.

With the release of FFMPEG 8, `hwupload` (a ffmpeg feature which is used by memories' VAAPI (AMD GPU) Hardware video decode) requires a device to be specified via `init_hw_device`. This is documented by the ffmpeg project here: https://trac.ffmpeg.org/wiki/Hardware/VAAPI#DeviceSelection

> Where filters require a device (for example, the `hwupload` filter), the device used in a filter graph can be specified with the `-filter_hw_device` option: 
> ```
> ffmpeg -init_hw_device vaapi=foo:/dev/dri/renderD128 -i ... -filter_hw_device foo -filter_complex > ...hwupload... ...
> ```

Right now, FFMPEG 8 + Memories + VAAPI AMD GPU Hardware decode errors out with `[hwupload @ 0x558ab089cd40] A hardware device reference is required to upload frames to.`

With FFMPEG 7 this was not required (the documentation has the word `can`, not `must`) and was initialized automatically, but with the release of FFMPEG 8 this became required. I am not sure why and started an inquiry in the FFMPEG-DEVEL mailing list: https://lists.ffmpeg.org/archives/list/ffmpeg-devel@ffmpeg.org/thread/BZF2EO2WGL6U52WAKFPOKNT53OJF2AYG/

Anyhow, this PR makes memories follow the documentation and initialize the VAAPI device explicitly.