### PR TITLE
Fixes for Android 13 and newer

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,10 +40,6 @@ dependencies {
     def media_version = "1.9.0"
     def room_version = "2.8.4"
 
-    implementation 'androidx.activity:activity-ktx:1.12.2'
-    implementation 'androidx.activity:activity-compose:1.12.2'
-    implementation 'androidx.compose.foundation:foundation-layout:1.10.1'
-    implementation 'androidx.compose.ui:ui:1.10.1'
     implementation 'androidx.core:core-ktx:1.17.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.7.1'

--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -442,12 +442,12 @@ class MainActivity : AppCompatActivity() {
      */
     private fun setFullscreen(value: Boolean) {
         if (value) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (SDK_INT >= Build.VERSION_CODES.P) {
                 window.attributes.layoutInDisplayCutoutMode =
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (SDK_INT >= Build.VERSION_CODES.R) {
                 window.insetsController?.apply {
                     hide(WindowInsets.Type.statusBars())
                     systemBarsBehavior =
@@ -463,12 +463,12 @@ class MainActivity : AppCompatActivity() {
                         or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
             }
         } else {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (SDK_INT >= Build.VERSION_CODES.P) {
                 window.attributes.layoutInDisplayCutoutMode =
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (SDK_INT >= Build.VERSION_CODES.R) {
                 window.insetsController?.apply {
                     show(WindowInsets.Type.statusBars())
                 }
@@ -507,7 +507,7 @@ class MainActivity : AppCompatActivity() {
         if (color == null) return
 
         // Set system bars
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        if (SDK_INT >= Build.VERSION_CODES.R) {
             val appearance =
                 WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS or WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
             window.insetsController?.setSystemBarsAppearance(


### PR DESCRIPTION
- when the device runs Android 16 or newer, the insets for the status bar and navigation bar are applied to the main view.
- when the device runs Android 13 or newer, the "back" gesture is handled by an custom dispatcher.
- minimum SDK version is updated from 27 to 30 since the web view does not work in older versions.

This will fix #1605 