### PR TITLE
Fix inset handling to be applied to the main view.

### DIFF
--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -85,7 +85,7 @@ class MainActivity : AppCompatActivity() {
 
         // Enable insets for Android 16 or newer
         if (SDK_INT >= 36) {
-            binding.webview.setOnApplyWindowInsetsListener { v, windowInsets ->
+            binding.coordinator.setOnApplyWindowInsetsListener { v, windowInsets ->
                 val insets = windowInsets.getInsets(WindowInsets.Type.systemBars())
                 // Apply the insets as a margin to the view.
                 v.updateLayoutParams<ViewGroup.MarginLayoutParams> {


### PR DESCRIPTION
This is an additional change to fix #1605 - the insets must be applied to the main container and not just the web view.