### PR TITLE
fix: also pass the loop video option on the native player

### DIFF
--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -338,7 +338,7 @@ class MainActivity : AppCompatActivity() {
         return false
     }
 
-    fun initializePlayer(uris: Array<Uri>, uid: Long) {
+    fun initializePlayer(uris: Array<Uri>, uid: Long, loop: Boolean = false) {
         if (player != null) {
             if (playerUid == uid) return
             player?.release()
@@ -402,6 +402,9 @@ class MainActivity : AppCompatActivity() {
                         exoPlayer.play()
                     }
                 })
+
+
+                exoPlayer.repeatMode = if (loop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
 
                 // Start the player
                 exoPlayer.playWhenReady = playWhenReady

--- a/android/app/src/main/java/gallery/memories/NativeX.kt
+++ b/android/app/src/main/java/gallery/memories/NativeX.kt
@@ -119,6 +119,11 @@ class NativeX(private val mCtx: MainActivity) {
 
     @JavascriptInterface
     fun playVideo(auid: String, fileid: Long, urlsArray: String) {
+        this.playVideo2(auid, fileid, urlsArray, false)
+    }
+
+    @JavascriptInterface
+    fun playVideo2(auid: String, fileid: Long, urlsArray: String, loop: Boolean = false) {
         mCtx.threadPool.submit {
             // Get URI of remote videos
             val urls = JSONArray(urlsArray)
@@ -132,9 +137,9 @@ class NativeX(private val mCtx: MainActivity) {
             // Play with exoplayer
             mCtx.runOnUiThread {
                 if (!videos.isEmpty()) {
-                    mCtx.initializePlayer(arrayOf(videos[0].uri), fileid)
+                    mCtx.initializePlayer(arrayOf(videos[0].uri), fileid, loop)
                 } else {
-                    mCtx.initializePlayer(list, fileid)
+                    mCtx.initializePlayer(list, fileid, loop)
                 }
             }
         }

--- a/src/native/api.ts
+++ b/src/native/api.ts
@@ -140,6 +140,7 @@ export type NativeX = {
   setShareBlobs: (objects: string) => void;
 
   /**
+   * This signature is kept for backward compatibility.
    * Play a video from the given AUID or URL(s).
    * @param auid AUID of file (will play local if available)
    * @param fileid File ID of the video (only used for file tracking)
@@ -148,6 +149,17 @@ export type NativeX = {
    * and HLS separately. The native client must try to play the first URL.
    */
   playVideo: (auid: string, fileid: number, urlArray: string) => void;
+
+  /**
+   * Play a video from the given AUID or URL(s).
+   * @param auid AUID of file (will play local if available)
+   * @param fileid File ID of the video (only used for file tracking)
+   * @param urlArray JSON-encoded array of URLs to play
+   * @param loop Whether the video should loop
+   * @details The URL array may contain multiple URLs, e.g. direct playback
+   * and HLS separately. The native client must try to play the first URL.
+   */
+  playVideo2: (auid: string, fileid: number, urlArray: string, loop?: boolean) => void;
 
   /**
    * Destroy the video player.

--- a/src/native/video.ts
+++ b/src/native/video.ts
@@ -1,5 +1,6 @@
 import { nativex } from './api';
 import { addOrigin } from './basic';
+import staticConfig from '@services/static-config';
 import type { IPhoto } from '@typings';
 
 /**
@@ -8,7 +9,12 @@ import type { IPhoto } from '@typings';
  * @param urls URLs to play (remote)
  */
 export async function playVideo(photo: IPhoto, urls: string[]) {
-  nativex?.playVideo?.(photo.auid ?? String(), photo.fileid, JSON.stringify(urls.map(addOrigin)));
+  const loop = staticConfig.getSync('video_loop') || false;
+  if (typeof nativex?.playVideo2 === 'function') {
+    nativex?.playVideo2?.(photo.auid ?? String(), photo.fileid, JSON.stringify(urls.map(addOrigin)), loop);
+  } else {
+    nativex?.playVideo?.(photo.auid ?? String(), photo.fileid, JSON.stringify(urls.map(addOrigin)));
+  }
 }
 
 /**


### PR DESCRIPTION
In #1578 I added the option "loop video".
Unfortunately I didn't realize that the Android app is using a native player.

So with this fix, also the native player is using the "loop video" option.

**Implementation detail:**
Because the app and the server may not be updated by the user at the same time, we have to provide backwards compatibility. I had to create a second `playVideo` method: `playVideo2`. I tested it with two signatures of `playVideo` in the android part, but an older App would not been able to play a video from a newer server.

I tested all server and app combinations with different versions (with this fix vs. without).

