### PR TITLE
docs: link community guide for running go-vod on a separate GPU host

### DIFF
--- a/docs/hw-transcoding.md
+++ b/docs/hw-transcoding.md
@@ -111,6 +111,10 @@ services:
     group_add: [109]
 ```
 
+!!! tip "GPU on a separate machine"
+
+    If your Nextcloud host does not have a GPU, you can also run go-vod on a different machine entirely and mount the Nextcloud data over NFS. A community-maintained setup guide and deploy script for this configuration (NVIDIA GPU with NVENC, NFS mount, external transcoder) is available at [jimnoneill/nextcloud-memories-gpu](https://github.com/jimnoneill/nextcloud-memories-gpu).
+
 ## Internal Transcoder
 
 Memories ships with an internal transcoder binary that you can directly use. In this case, you must install the drivers and ffmpeg on the same host as Nextcloud, and Memories will automatically handle starting and communicating with go-vod. This is also the default setup when you enable transcoding without hardware acceleration.


### PR DESCRIPTION
## Summary

Small docs addition under the External Transcoder section of `docs/hw-transcoding.md`.

The existing examples in that section assume go-vod runs on the same host as Nextcloud (shared docker network, shared data volumes). I put together a setup guide for the other common case, where the Nextcloud storage server does not have a GPU and the transcoder runs on a separate machine with the Nextcloud data mounted over NFS. Useful for folks running Nextcloud on a NAS or low-power box who have a homelab node or old gaming PC with an NVIDIA card sitting around.

The repo has a deploy script that handles NFS exports on the storage side, the go-vod container with the NVIDIA Container Toolkit on the GPU side, and the `occ` calls to configure Memories. It also documents the GOP size workaround up front, which cost me an evening the first time.

Repo: https://github.com/jimnoneill/nextcloud-memories-gpu

Happy to adjust the wording or the placement if you would rather link from somewhere else, or skip this entirely if you do not want external setup guides referenced from the docs. No hard feelings either way.

Thanks for Memories. It is the piece that made self hosting photos actually pleasant.

## Test plan

- [x] Rendered the admonition in mkdocs locally to confirm it matches the style of the surrounding tips
- [x] Verified link target resolves