### PR TITLE
Map - fix Access blocked 403r

### DIFF
--- a/src/components/top-matter/MapSplitMatter.vue
+++ b/src/components/top-matter/MapSplitMatter.vue
@@ -89,7 +89,7 @@ export default defineComponent({
       maxBoundsViscosity: 0.9,
     },
     tileLayerOptions: {
-        referrerPolicy: 'origin',
+      referrerPolicy: 'origin',
     },
     clusters: [] as IMarkerCluster[],
     animMarkers: false,

--- a/src/components/top-matter/MapSplitMatter.vue
+++ b/src/components/top-matter/MapSplitMatter.vue
@@ -15,7 +15,7 @@
       @zoomend="refreshDebounced"
       :options="mapOptions"
     >
-      <LTileLayer :url="tileurl" :attribution="attribution" :noWrap="true" />
+      <LTileLayer :url="tileurl" :attribution="attribution" :noWrap="true" :options="tileLayerOptions" />
       <LMarker v-for="cluster of clusters" :key="cluster.id" :lat-lng="cluster.center" @click="zoomTo(cluster)">
         <LIcon :icon-anchor="[24, 24]" :className="clusterIconClass(cluster)">
           <div class="preview">
@@ -87,6 +87,9 @@ export default defineComponent({
     mapOptions: {
       maxBounds: latLngBounds([-90, -180], [90, 180]),
       maxBoundsViscosity: 0.9,
+    },
+    tileLayerOptions: {
+        referrerPolicy: 'origin',
     },
     clusters: [] as IMarkerCluster[],
     animMarkers: false,


### PR DESCRIPTION
Should fix #1637

Configure the leaflet library to send the `referer` header when requesting map tiles from OSM servers.

As described in:
https://wiki.openstreetmap.org/wiki/Blocked_tiles
https://leafletjs.com/reference.html#tilelayer-referrerpolicy

Verified in my local dev environment.