### PR TITLE
Workaround to avoid logging errors when browsing public albums

### DIFF
--- a/lib/Db/FsManager.php
+++ b/lib/Db/FsManager.php
@@ -41,6 +41,7 @@ use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IShare;
 
 final class FsManager
@@ -317,7 +318,17 @@ final class FsManager
         }
 
         // Get share by token
-        $share = \OC::$server->get(\OCP\Share\IManager::class)->getShareByToken($token);
+        $share = null;
+
+        // This might be invoked for public albums, in this case the token parameter
+        // contains the collaborator_id of the album rather than a proper share token.
+        //
+        // Catch the ShareNotFound exception to enable further processing of the request.
+        try {
+            $share = \OC::$server->get(\OCP\Share\IManager::class)->getShareByToken($token);
+        } catch (ShareNotFound $e) {
+            return null;
+        }
         if (!self::validateShare($share)) {
             return null;
         }


### PR DESCRIPTION
Workaround for #1652

Also resolves the issue of viewing photo information (metadata) in public albums.

Probably a better solution would be to refactor the client code to not send the `token` parameter in such case (in the `api/image/info` request). I have not been able to find how to do it, so I am submitting this PR as a workaround.