### PR TITLE
Avoid crash when no app can open an external intent

### DIFF
--- a/android/app/src/main/java/gallery/memories/MainActivity.kt
+++ b/android/app/src/main/java/gallery/memories/MainActivity.kt
@@ -1,6 +1,7 @@
 package gallery.memories
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
@@ -230,7 +231,11 @@ class MainActivity : AppCompatActivity() {
                 }
 
                 // Open external links in browser
-                Intent(Intent.ACTION_VIEW, request.url).apply { startActivity(this) }
+                try {
+                    Intent(Intent.ACTION_VIEW, request.url).apply { startActivity(this) }
+                } catch (e: ActivityNotFoundException) {
+                    Toast.makeText(view.context, "No app found to open this link", Toast.LENGTH_SHORT).show()
+                }
 
                 return true
             }


### PR DESCRIPTION
`MainActivity` opens external intents from the WebView with `startActivity(Intent(ACTION_VIEW, ...))`. If the device has no app that can handle the intent this throws `ActivityNotFoundException` and crashes the app.

This wraps the launch in a try/catch and shows a short toast when nothing can open the link. The in app navigation is unchanged.

Closes #1674
