### PR TITLE
Fix: Videos displaying incorrect time in timeline

### DIFF
--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -224,9 +224,11 @@ final class Exif
             throw new \Exception("Blacklisted date: {$exifDate}");
         }
 
-        // Force the timezone to be the same as parseTz
+        // Force the timezone to be the same as parseTz, unless offset is present
         if ($exifTz) {
             $parsedDate->setTimezone($exifTz);
+        } elseif ($parsedDate->getOffset() !== 0) {
+          $parsedDate->setTimezone(new \DateTimeZone($parsedDate->format('O')));
         }
 
         return $parsedDate;


### PR DESCRIPTION
# Videos displaying incorrect time in timeline

> [!NOTE]
> Tested with iOS mov files because that was the issue I was hitting, but should fix any videos with the same problem.

Videos recorded with a UTC offset were being displayed at the wrong time in the timeline, showing up as UTC time instead.

Since  `exiftool` is already invoked with `-api QuickTimeUTC=1`, it appends the local offset to `CreateDate`. However, files that do not contain `OffsetTimeOriginal`, `OffsetTime`, or `LocationTZID` tags make `parseExifDate()` set `$parseTz = UTC`.

`forgetTimezone()` then calls `format('Y-m-d H:i:s')` on a UTC `DateTime`, producing UTC time instead of local time.

## Fix

After parsing, check whether the resulting `DateTime` has a non-zero offset. If so, set the timezone to match that offset so `forgetTimezone()` sees the correct local time.

## Impact

- **Files with offset in the date string**: now display the correct local time in the timeline
- **Files with no offset in the date string**: unaffected

> [!WARNING]  
> Will require a reindexing of affected files.

### Related issues
  
- Fixes #1495
- Fixed #1569
- Probably more