### PR TITLE
share: keep a non-empty file name for navigator.share

### DIFF
--- a/src/components/modal/ShareModal.vue
+++ b/src/components/modal/ShareModal.vue
@@ -301,8 +301,12 @@ export default defineComponent({
       const files: File[] = [];
       for await (const responses of dav.runInParallel(calls, 8)) {
         for (const res of responses.filter(Boolean)) {
-          const filename = res!.headers['content-disposition']?.match(/filename="(.+)"/)?.[1] ?? '';
           const blob = res!.data;
+          // Content-Disposition may be unquoted; an empty file name makes navigator.share()
+          // fail on Safari, which infers the type from the name, so fall back to the MIME type.
+          const ext = (blob.type.split('/').pop() || 'bin').replace('jpeg', 'jpg');
+          const cd = res!.headers['content-disposition'] ?? '';
+          const filename = cd.match(/filename="?([^";]+)"?/)?.[1] ?? `memories.${ext}`;
           files.push(new File([blob], filename, { type: blob.type }));
         }
       }


### PR DESCRIPTION
Sharing a photo with "Reduced Size" or "High Resolution" does nothing on macOS Safari. The share sheet opens empty and `navigator.share()` rejects with `AbortError: Abort due to cancellation of share`. "Original File" and "Public Link" work fine. Most visible with HEIC, but it's not codec specific.

In `shareWithHref()` the filename comes from `Content-Disposition`:

```ts
const filename = res!.headers['content-disposition']?.match(/filename="(.+)"/)?.[1] ?? '';
files.push(new File([blob], filename, { type: blob.type }));
```

That regex only matches a quoted filename, but the image endpoints send it unquoted:

```
Content-Disposition: attachment; filename=IMG_1234.HEIC.jpg
```

So the match fails, the File gets an empty name, and Safari (which picks the type from the name extension) can't build the share sheet. Chrome and Android don't care about the empty name, so it only breaks on Safari.

The fix matches the unquoted form too and falls back to a name from the blob mime type so it's never empty.

To confirm it's the name: with the same blob, `new File([blob], '', { type: 'image/jpeg' })` gives the empty sheet and AbortError, while `new File([blob], 'photo.jpg', { type: 'image/jpeg' })` shares fine. `navigator.canShare({ files })` returns true either way.

Tested on Safari 17, Memories 7.8.2 / Nextcloud 32.0.9.
