### PR TITLE
Fix native video playback in static viewer

### DIFF
--- a/src/components/viewer/Viewer.vue
+++ b/src/components/viewer/Viewer.vue
@@ -636,6 +636,13 @@ export default defineComponent({
         const photo = e.slide?.data?.photo;
         this.setFragment(photo);
         this.updateTitle(photo);
+
+        // Mark active slide for native video pass-through
+        this.photoswipe?.element?.querySelectorAll('.pswp__item').forEach((el) => el.classList.remove('active'));
+        e.slide.holderElement?.classList.add('active');
+
+        // Add type class to body for native video pass-through
+        document.body.classList.toggle(BODY_VIEWER_VIDEO, !!(photo?.flag & this.c.FLAG_IS_VIDEO));
       });
 
       // Show and hide controls
@@ -872,13 +879,6 @@ export default defineComponent({
             thumb.scrollIntoView({ block: 'center' });
           }
         }
-
-        // Remove active class from others and add to this one
-        photoswipe.element?.querySelectorAll('.pswp__item').forEach((el) => el.classList.remove('active'));
-        e.slide.holderElement?.classList.add('active');
-
-        // Add type class to body
-        document.body.classList.toggle(BODY_VIEWER_VIDEO, !!(e.slide.data?.photo?.flag & this.c.FLAG_IS_VIDEO));
       });
 
       photoswipe.init();


### PR DESCRIPTION
## Description

Fix Android native video playback when a video is opened through a static PhotoSwipe viewer, notably from "On This Day" / memories.

The Android native player is rendered behind the WebView. Native video pass-through relies on two pieces of viewer state:

- the `viewer-video` class on `<body>`;
- the `active` class on the current `.pswp__item`.

Previously this logic was registered only in `openDynamic()`, which is used by the normal timeline.

`openStatic()`, used by "On This Day", did not set those classes. ExoPlayer therefore played the video correctly, including audio, but the PhotoSwipe/WebView layer remained visible above the native PlayerView, resulting in a black/grey video.

This change moves the native slide-state handling into `createBase()`, so it is shared by both static and dynamic viewers.

Timeline-specific thumbnail scrolling remains in `openDynamic()`.

## Testing

- `npm run build` ?
- Android `assembleDebug` ?
- Reproduced the issue before the fix on Android
- Verified the same "On This Day" video after the fix:
  - video visible ?
  - audio working ?
- Verified switching between images and videos in the viewer ?

Fixes #1226
Related to #1651
