### PR TITLE
fix(go-vod): initialize CUDA device for NVENC transcoding

### DIFF
--- a/go-vod/transcoder/stream.go
+++ b/go-vod/transcoder/stream.go
@@ -374,7 +374,9 @@ func (s *Stream) transcodeArgs(startAt float64, isHls bool) []string {
 		args = append(args, strings.Split(extra, " ")...)
 	} else if s.c.NVENC {
 		CV = ENCODER_NVENC
-		extra := "-hwaccel cuda"
+		// ffmpeg >= 8 requires an explicit device for hwupload; without it the
+		// filter chain fails with "A hardware device reference is required".
+		extra := "-hwaccel cuda -hwaccel_output_format cuda -init_hw_device cuda=memories -filter_hw_device memories"
 		args = append(args, strings.Split(extra, " ")...)
 	}
 


### PR DESCRIPTION
## Problem

NVENC transcoding fails on ffmpeg 8. Every transcode aborts immediately and the client sees a perpetual loading spinner (Memories logs `Transcode failed: Transcoder returned 408`):

```
[hwupload @ ...] A hardware device reference is required to upload frames to.
[AVFilterGraph @ ...] Error initializing filters
Error opening output file -.
ffmpeg exited with status: 234
```

## Cause

The NVENC branch in `transcodeArgs` passes only `-hwaccel cuda`:

```go
} else if s.c.NVENC {
	CV = ENCODER_NVENC
	extra := "-hwaccel cuda"
```

The filter chain is then built as `format=nv12|cuda,hwupload,scale_cuda=...`, but nothing ever initializes a CUDA device or binds one to the filter graph. Through ffmpeg 7 this worked because `hwupload` would implicitly derive a device; ffmpeg 8 requires it explicitly, so the graph fails to initialize.

The VAAPI branch directly above already does this correctly, passing `-hwaccel_output_format`, `-init_hw_device` and `-filter_hw_device`.

## Fix

Make the NVENC branch symmetric with VAAPI:

```go
extra := "-hwaccel cuda -hwaccel_output_format cuda -init_hw_device cuda=memories -filter_hw_device memories"
```

No version gate is included, deliberately. `-init_hw_device`, `-filter_hw_device` and `-hwaccel_output_format` have existed since ffmpeg 3.4, and the VAAPI branch already uses them unconditionally. They were always correct here, just optional before ffmpeg 8. Gating them would add a version-parsing failure mode and diverge from how VAAPI is handled.

Keeping decoded frames in device memory additionally avoids a GPU to CPU and back round trip before `scale_cuda`.

## Verification

Fedora 44, ffmpeg 8.1.2, NVIDIA T600 (driver 610.57.04), Nextcloud 34.0.3.2, Memories 8.0.1, running go-vod as an external transcoder.

Before: every transcode failed with the error above.

After: HEVC 1080p sources transcode and play. Segments are produced normally and the GPU is engaged, with encoder utilization at 62% and decoder at 70% during transcode. The resulting command is:

```
ffmpeg -loglevel warning -hwaccel cuda -hwaccel_output_format cuda \
  -init_hw_device "cuda=memories" -filter_hw_device memories -i INPUT \
  -vf "format=nv12|cuda,hwupload,scale_cuda=..." -c:v h264_nvenc ...
```

The only remaining ffmpeg stderr is the expected `More than 1000 frames duplicated` notice from the existing `scale_cuda` keyframe workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eky1CPt1rz6BWLAqWVNmU9
