### PR TITLE
fix(exif): increase timeout to 120 seconds

### DIFF
--- a/lib/Exif.php
+++ b/lib/Exif.php
@@ -14,7 +14,7 @@ use OCP\Files\File;
 final class Exif
 {
     private const FORBIDDEN_EDIT_MIMES = ['image/bmp', 'image/x-dcraw', 'video/MP2T']; // also update const.ts
-    private const EXIFTOOL_TIMEOUT = 30000;
+    private const EXIFTOOL_TIMEOUT = 120000;
     private const EXIFTOOL_ARGS = ['-api', 'QuickTimeUTC=1', '-api', 'LargeFileSupport=1', '-n', '-json'];
 
     /** Opened instance of exiftool when running in command mode */


### PR DESCRIPTION
30 seconds is often not long enough, especially for slower storage or larger files. Most installations should tolerate 120 seconds without any issue, and this allows more time to edit large files or groups of larger files.

Closes https://github.com/pulsejet/memories/issues/1461