### PR TITLE
fix(public): password protected link shares (Nextcloud ≥ 31.0.11 / 32.0.2 / 33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- **Fix**: Password protected link shares fail with "Share is password protected and user is not authenticated" (Nextcloud ≥ 31.0.11 / 32.0.2 / 33)
 - **Fix**: Copied files are now immediately indexed
 - **Fix**: Improved and 20x faster planet database setup
 - **Fix**: Fix broken cover images on SQLite

--- a/e2e/011-public-folder-password.spec.ts
+++ b/e2e/011-public-folder-password.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { appUrl, baseUrl, e2eHeaders, psub } from './navigation';
+import { DavClient, withPublicAPI, withPublicPage } from './utils';
+
+import type { APIRequestContext } from '@playwright/test';
+import type { IShare } from '@typings';
+
+test.use({ extraHTTPHeaders: e2eHeaders() });
+
+test.describe('Password protected folder share', () => {
+  const folderDir = psub('/for-public-pw-%wid');
+  const folderFiles = ['RmjH76vMWrI.jpg', 'dHLhDeEgxsg.jpg', 'kvRlouf0RTs.jpg'];
+  const sharePassword = 'Sup3r-s3cret!';
+
+  let folderToken: string;
+  let folderShareId: string;
+
+  test.beforeAll(async ({ request }) => {
+    const dav = new DavClient(request);
+    const shares = new ShareAPI(request);
+
+    await dav.deleteFile(folderDir, true);
+    await dav.copyFile('/for-other', folderDir);
+
+    const share = await shares.create(folderDir);
+    folderToken = share.token;
+    folderShareId = share.id;
+
+    await shares.setPassword(folderShareId, sharePassword);
+  });
+
+  test.afterAll(async ({ request }) => {
+    const shares = new ShareAPI(request);
+    const dav = new DavClient(request);
+
+    if (folderShareId) {
+      await shares.remove(folderShareId).catch(() => {});
+    }
+    await dav.deleteFile(folderDir, true);
+  });
+
+  test('@api Unauthenticated access to protected share is rejected', async () => {
+    await withPublicAPI(async (request) => {
+      const url = new URL(`${appUrl}/api/days`);
+      url.searchParams.set('nopreload', '1');
+      url.searchParams.set('token', folderToken);
+      const res = await request.get(url.toString());
+      expect(res.ok()).toBe(false);
+      expect(res.status()).toBe(403);
+    });
+  });
+
+  test('@ui Protected share shows photos after entering the password', async ({ browser }) => {
+    await withPublicPage(browser, async (page) => {
+      await page.goto(`${appUrl}/s/${folderToken}`);
+
+      // Nextcloud's public share authentication page (core/templates/publicshareauth)
+      const authForm = page.locator('#core-public-share-auth');
+      await expect(authForm).toBeVisible();
+      await authForm.locator('input[name="password"]').fill(sharePassword);
+      await authForm.locator('button[type="submit"]').click();
+
+      // The timeline is populated through the API using the same session
+      await expect(page.locator('.p-outer')).toHaveCount(folderFiles.length);
+
+      // The same session must also be authenticated for WebDAV, which is what
+      // the regular share page, download links and clients use.
+      const dav = await page.request.fetch(`${baseUrl}/public.php/dav/files/${folderToken}/`, {
+        method: 'PROPFIND',
+        headers: { Depth: '1' },
+      });
+      expect(dav.status()).toBe(207);
+    });
+  });
+
+  test('@ui Wrong password is rejected', async ({ browser }) => {
+    await withPublicPage(browser, async (page) => {
+      await page.goto(`${appUrl}/s/${folderToken}`);
+
+      const authForm = page.locator('#core-public-share-auth');
+      await authForm.locator('input[name="password"]').fill('definitely-wrong');
+      await authForm.locator('button[type="submit"]').click();
+
+      await expect(page.locator('#core-public-share-auth')).toBeVisible();
+      await expect(page.locator('.p-outer')).toHaveCount(0);
+    });
+  });
+});
+
+// Minimal share helper: create/delete through the Memories API, set the
+// password through the OCS sharing API (Memories has no endpoint for that).
+class ShareAPI {
+  constructor(private request: APIRequestContext) {}
+
+  async create(path: string): Promise<IShare> {
+    const res = await this.request.post(`${appUrl}/api/share/node`, {
+      data: { path },
+    });
+    expect(res.ok()).toBeTruthy();
+    return res.json();
+  }
+
+  async setPassword(fullId: string, password: string): Promise<void> {
+    // Memories returns IShare::getFullId() ("ocinternal:123"), OCS wants the numeric part
+    const id = fullId.split(':').pop();
+    const res = await this.request.put(`${baseUrl}/ocs/v2.php/apps/files_sharing/api/v1/shares/${id}?format=json`, {
+      form: { password },
+    });
+    expect(res.ok()).toBeTruthy();
+  }
+
+  async remove(id: string): Promise<void> {
+    const res = await this.request.post(`${appUrl}/api/share/delete`, {
+      data: { id },
+    });
+    expect(res.ok()).toBeTruthy();
+  }
+}

--- a/lib/Controller/PublicController.php
+++ b/lib/Controller/PublicController.php
@@ -30,6 +30,14 @@ use OCP\Share\IShare;
 
 final class PublicController extends AuthPublicShareController
 {
+    /**
+     * Session key holding the IDs of the shares this session is authenticated for.
+     *
+     * Value of \OCA\DAV\Connector\Sabre\PublicAuth::DAV_AUTHENTICATED; declared here since
+     * the dav app is not available for static analysis in this project.
+     */
+    private const DAV_AUTHENTICATED = 'public_link_authenticated';
+
     /** @psalm-suppress PropertyNotSetInConstructor */
     protected IShare $share;
 
@@ -173,6 +181,31 @@ final class PublicController extends AuthPublicShareController
     {
         /** @psalm-suppress RedundantConditionGivenDocblockType */
         return null !== $this->share->getPassword();
+    }
+
+    /**
+     * Called by AuthPublicShareController after a successful password login.
+     *
+     * The base class only records the login for the AppFramework (used by isAuthenticated()).
+     * The WebDAV backend (\OCA\DAV\Connector\Sabre\PublicAuth) keeps its own list of authenticated
+     * share IDs in the session instead, which files_sharing populates in its own ShareController.
+     * We need to do the same, otherwise a session that logged in here cannot access the share
+     * over WebDAV afterwards (regular share page, download links, Nextcloud clients).
+     */
+    #[\Override]
+    protected function authSucceeded(): void
+    {
+        $allowedShareIds = $this->session->get(self::DAV_AUTHENTICATED);
+        if (!\is_array($allowedShareIds)) {
+            $allowedShareIds = [];
+        }
+
+        $shareId = $this->share->getId();
+        if (!\in_array($shareId, $allowedShareIds, true)) {
+            $allowedShareIds[] = $shareId;
+        }
+
+        $this->session->set(self::DAV_AUTHENTICATED, $allowedShareIds);
     }
 
     protected function redirectIfOwned(IShare $share): void

--- a/lib/Db/FsManager.php
+++ b/lib/Db/FsManager.php
@@ -29,6 +29,7 @@ use OC\Files\Search\SearchQuery;
 use OCA\Memories\ClustersBackend;
 use OCA\Memories\Exceptions;
 use OCA\Memories\Util;
+use OCP\AppFramework\PublicShareController;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -335,18 +336,43 @@ final class FsManager
 
         // Check if share is password protected
         if (!empty($password = $share->getPassword())) {
-            $session = \OC::$server->get(\OCP\ISession::class);
-
-            // https://github.com/nextcloud/server/blob/0447b53bda9fe95ea0cbed765aa332584605d652/lib/public/AppFramework/PublicShareController.php#L119
-            if (
-                $session->get('public_link_authenticated_token') !== $token
-                || $session->get('public_link_authenticated_password_hash') !== $password
-            ) {
-                throw new \Exception('Share is password protected and user is not authenticated');
+            if (!self::isShareAuthenticated($token, $password)) {
+                throw Exceptions::Forbidden('Share is password protected and user is not authenticated');
             }
         }
 
         return $share;
+    }
+
+    /**
+     * Check whether the current session is authenticated for a password protected link share.
+     *
+     * This mirrors \OCP\AppFramework\PublicShareController::validateTokenSession(). After a
+     * successful login, AuthPublicShareController::authenticate() stores the token together with
+     * the password hash of the share as a JSON encoded map in the session, so that the session
+     * becomes invalid again when the password of the share is changed.
+     *
+     * This format replaced the former public_link_authenticated_token/_password_hash keys in
+     * Nextcloud 33 (declared @since 33.0.0) and was backported to 32.0.2 and 31.0.11.
+     *
+     * @param string $token        Share token
+     * @param string $passwordHash Password hash of the share (IShare::getPassword())
+     */
+    private static function isShareAuthenticated(string $token, string $passwordHash): bool
+    {
+        $session = \OC::$server->get(\OCP\ISession::class);
+
+        $allowedTokensJSON = $session->get(PublicShareController::DAV_AUTHENTICATED_FRONTEND);
+        if (!\is_string($allowedTokensJSON)) {
+            return false;
+        }
+
+        $allowedTokens = json_decode($allowedTokensJSON, true);
+        if (!\is_array($allowedTokens)) {
+            return false;
+        }
+
+        return ($allowedTokens[$token] ?? null) === $passwordHash;
     }
 
     /**


### PR DESCRIPTION
Closes #1579
Closes #1700

## Problem

Since Nextcloud 31.0.11 / 32.0.2 and on all 33.x / 34.x releases, password-protected link shares are broken in Memories. Two separate problems:

1. **Empty timeline (API error):** Opening a password-protected share via `/apps/memories/s/{token}` prompts for the password and accepts it, but then renders an empty timeline. All API calls fail with `Share is password protected and user is not authenticated` (HTTP 500, logged as an error). Caused by an upstream change in how the login is stored in the session (see below).
2. **WebDAV access denied:** After a successful login on the Memories share page, the same session cannot access the share over WebDAV: the regular share page (`/s/{token}`) skips the password prompt but fails to load the file list with `Invalid response: No root multistatus found` (Sabre `NotAuthenticated`), and each request registers a brute-force attempt. This is not upstream-related; the marker has been missing in Memories since password-protected shares were introduced (`cb04070a`), it just went unnoticed while (1) did not exist.

Related, not closed by this PR: #1634 (public uploads build the DAV URL with `null` instead of the token – separate frontend bug; note that this PR is a prerequisite for uploads to work on password-protected shares once that is fixed). #348 is about album links (`/a/{token}`), which have no password mechanism.

## Root cause

Nextcloud keeps two independent session markers for password-protected link shares:

1. **AppFramework:** nextcloud/server#55955 ("fix(dav): allow multiple link shares token in session") replaced the session keys `public_link_authenticated_token` / `public_link_authenticated_password_hash` with a JSON map of `token => passwordHash` under `PublicShareController::DAV_AUTHENTICATED_FRONTEND`. Annotated `@since 33.0.0`, but backported (nextcloud/server#55961) and shipped in 32.0.2 and 31.0.11 on 2025-11-28 (verified tag by tag: 31.0.10/32.0.1 old, 31.0.11/32.0.2 new; 30.x never got it). `FsManager::getShareObject()` still checked the old keys, which the server no longer writes.
2. **WebDAV:** `OCA\DAV\Connector\Sabre\PublicAuth` checks an array of share IDs under `public_link_authenticated`. Core's `files_sharing` `ShareController::authSucceeded()` populates it after a login on the regular share page. Memories' `PublicController` extends the same `AuthPublicShareController` but never overrode `authSucceeded()`, so a login on the Memories page leaves the DAV marker empty.

`FsManager::getShareObject()` is the single place where Memories checks share authentication for its API (days, image, video, download, folders), so one change covers all endpoints.

## Changes

- `lib/Db/FsManager.php`: check the session like `PublicShareController::validateTokenSession()` (JSON map under `DAV_AUTHENTICATED_FRONTEND`, so changing the share password still invalidates existing sessions). Unauthenticated access returns 403 instead of an error-logged 500.
- `lib/Controller/PublicController.php`: override `authSucceeded()` and add the share ID to `public_link_authenticated`, mirroring core's `ShareController::authSucceeded()`. The key is a local constant because the `dav` app is not part of this project's psalm `extraFiles`.
- `e2e/011-public-folder-password.spec.ts`: regression test – unauthenticated API access is rejected (403), the timeline loads after entering the password, the same session can `PROPFIND` the share via `public.php/dav`, and a wrong password is rejected. The password is set through the OCS sharing API since Memories has no endpoint for it.
- `CHANGELOG.md`

`DAV_AUTHENTICATED_FRONTEND` exists on every server version this app supports (33/34); no version gating needed.

## Note on authorship

Root-cause analysis and parts of the patch were done with Claude (Anthropic). I verified the analysis myself against the `nextcloud/server` tags listed above and tested the change on my own instance (including reverting it); the sign-off is mine and I take responsibility for the submission.

## How to test

1. Create a link share of a folder with photos and set a password.
2. Open `/apps/memories/s/{token}` in a private window, enter the password.
   - before: empty timeline, `user is not authenticated` in the log
   - after: photos load
3. In the same window open `/s/{token}`.
   - before: no password prompt, then `No root multistatus found`
   - after: file list loads
4. Reverse order (login on `/s/{token}` first, then open the Memories link): the file list already worked before; the Memories timeline only works with this change.

Verified on Memories 8.1.0 / Nextcloud 34.0.3.2 (Docker Compose, MariaDB 12.3): both symptoms reproduced before the change, gone after applying the two `lib/` files, back again after reverting them.